### PR TITLE
Add support for OpenSUSE 13.2

### DIFF
--- a/lib/fauxhai/platforms/opensuse/13.2.json
+++ b/lib/fauxhai/platforms/opensuse/13.2.json
@@ -1,0 +1,663 @@
+{
+  "kernel": {
+    "name": "Linux",
+    "release": "3.16.6-2-default",
+    "version": "#1 SMP Mon Oct 20 13:47:22 UTC 2014 (feb42ea)",
+    "machine": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "iscsi_ibft": {
+        "size": "12862",
+        "refcount": "0"
+      },
+      "iscsi_boot_sysfs": {
+        "size": "16000",
+        "refcount": "1"
+      },
+      "af_packet": {
+        "size": "40034",
+        "refcount": "0"
+      },
+      "crct10dif_pclmul": {
+        "size": "14307",
+        "refcount": "0"
+      },
+      "crc32_pclmul": {
+        "size": "13133",
+        "refcount": "0"
+      },
+      "crc32c_intel": {
+        "size": "22094",
+        "refcount": "0"
+      },
+      "ghash_clmulni_intel": {
+        "size": "13230",
+        "refcount": "0"
+      },
+      "ppdev": {
+        "size": "17671",
+        "refcount": "0"
+      },
+      "aesni_intel": {
+        "size": "152552",
+        "refcount": "0"
+      },
+      "aes_x86_64": {
+        "size": "17131",
+        "refcount": "1"
+      },
+      "lrw": {
+        "size": "13286",
+        "refcount": "1"
+      },
+      "gf128mul": {
+        "size": "14951",
+        "refcount": "1"
+      },
+      "glue_helper": {
+        "size": "13990",
+        "refcount": "1"
+      },
+      "ablk_helper": {
+        "size": "13597",
+        "refcount": "1"
+      },
+      "cryptd": {
+        "size": "16263",
+        "refcount": "3"
+      },
+      "pcspkr": {
+        "size": "12718",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "13434",
+        "refcount": "0"
+      },
+      "i2c_piix4": {
+        "size": "22166",
+        "refcount": "0"
+      },
+      "floppy": {
+        "size": "73758",
+        "refcount": "0"
+      },
+      "parport_pc": {
+        "size": "41414",
+        "refcount": "0"
+      },
+      "parport": {
+        "size": "46395",
+        "refcount": "2"
+      },
+      "processor": {
+        "size": "40484",
+        "refcount": "0"
+      },
+      "sg": {
+        "size": "40630",
+        "refcount": "0"
+      },
+      "fuse": {
+        "size": "100461",
+        "refcount": "1"
+      },
+      "dm_mod": {
+        "size": "111114",
+        "refcount": "0"
+      },
+      "squashfs": {
+        "size": "52494",
+        "refcount": "0"
+      },
+      "loop": {
+        "size": "28313",
+        "refcount": "0"
+      },
+      "virtio_blk": {
+        "size": "18129",
+        "refcount": "0"
+      },
+      "virtio_ring": {
+        "size": "21225",
+        "refcount": "1"
+      },
+      "virtio": {
+        "size": "14474",
+        "refcount": "1"
+      },
+      "ata_generic": {
+        "size": "12923",
+        "refcount": "0"
+      },
+      "xen_vnif": {
+        "size": "37965",
+        "refcount": "0"
+      },
+      "xen_balloon": {
+        "size": "18837",
+        "refcount": "1"
+      },
+      "xen_vbd": {
+        "size": "31331",
+        "refcount": "2"
+      },
+      "ata_piix": {
+        "size": "35052",
+        "refcount": "0"
+      },
+      "xen_platform_pci": {
+        "size": "103752",
+        "refcount": "3"
+      },
+      "button": {
+        "size": "13971",
+        "refcount": "0"
+      }
+    }
+  },
+  "os": "linux",
+  "os_version": "3.16.6-2-default",
+  "lsb": {
+  },
+  "platform_version": "13.2",
+  "platform": "opensuse",
+  "platform_family": "suse",
+  "filesystem": {
+    "/dev/hda1": {
+      "kb_size": "9156984",
+      "kb_used": "1396068",
+      "kb_available": "7272724",
+      "percent_used": "17%",
+      "mount": "/",
+      "total_inodes": "589824",
+      "inodes_used": "74235",
+      "inodes_available": "515589",
+      "inodes_percent_used": "13%",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "data=ordered"
+      ],
+      "uuid": "6cf2a926-3d35-4ebe-8bba-99891188e8f0"
+    },
+    "devtmpfs": {
+      "kb_size": "477568",
+      "kb_used": "8",
+      "kb_available": "477560",
+      "percent_used": "1%",
+      "mount": "/dev",
+      "total_inodes": "119392",
+      "inodes_used": "364",
+      "inodes_available": "119028",
+      "inodes_percent_used": "1%",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "size=477568k",
+        "nr_inodes=119392",
+        "mode=755"
+      ]
+    },
+    "tmpfs": {
+      "kb_size": "509332",
+      "kb_used": "0",
+      "kb_available": "509332",
+      "percent_used": "0%",
+      "mount": "/sys/fs/cgroup",
+      "total_inodes": "127333",
+      "inodes_used": "15",
+      "inodes_available": "127318",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ]
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "securityfs": {
+      "mount": "/sys/kernel/security",
+      "fs_type": "securityfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "cgroup": {
+      "mount": "/sys/fs/cgroup/hugetlb",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "hugetlb"
+      ]
+    },
+    "pstore": {
+      "mount": "/sys/fs/pstore",
+      "fs_type": "pstore",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "systemd-1": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "autofs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "fd=20",
+        "pgrp=1",
+        "timeout=300",
+        "minproto=5",
+        "maxproto=5",
+        "direct"
+      ]
+    },
+    "mqueue": {
+      "mount": "/dev/mqueue",
+      "fs_type": "mqueue",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "hugetlbfs": {
+      "mount": "/dev/hugepages",
+      "fs_type": "hugetlbfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "fusectl": {
+      "mount": "/sys/fs/fuse/connections",
+      "fs_type": "fusectl",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "rootfs": {
+      "mount": "/",
+      "fs_type": "rootfs",
+      "mount_options": [
+        "rw"
+      ]
+    }
+  },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "ohai_time": 1430039596.3605604,
+  "dmi": {
+    "dmidecode_version": "2.12",
+    "smbios_version": "2.4",
+    "structures": {
+      "count": "11",
+      "size": "310"
+    },
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "Xen",
+          "Version": "4.2.amazon",
+          "Release Date": "12/03/2014",
+          "Address": "0xE8000",
+          "Runtime Size": "96 kB",
+          "ROM Size": "64 kB",
+          "Characteristics": {
+            "PCI is supported": null,
+            "EDD is supported": null,
+            "Targeted content distribution is supported": null
+          },
+          "BIOS Revision": "4.2"
+        }
+      ],
+      "vendor": "Xen",
+      "version": "4.2.amazon",
+      "release_date": "12/03/2014",
+      "address": "0xE8000",
+      "runtime_size": "96 kB",
+      "rom_size": "64 kB",
+      "bios_revision": "4.2"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0100",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "Xen",
+          "Product Name": "HVM domU",
+          "Version": "4.2.amazon",
+          "Serial Number": "ec2e7f82-91b5-0a6e-c778-2b7f9519e49e",
+          "UUID": "EC2E7F82-91B5-0A6E-C778-2B7F9519E49E",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Not Specified"
+        }
+      ],
+      "manufacturer": "Xen",
+      "product_name": "HVM domU",
+      "version": "4.2.amazon",
+      "serial_number": "ec2e7f82-91b5-0a6e-c778-2b7f9519e49e",
+      "uuid": "EC2E7F82-91B5-0A6E-C778-2B7F9519E49E",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Not Specified"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0300",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Xen",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "Unknown"
+        }
+      ],
+      "manufacturer": "Xen",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "Not Specified",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "Unknown"
+    },
+    "processor": {
+      "all_records": [
+        {
+          "record_id": "0x0401",
+          "size": "4",
+          "application_identifier": "Processor Information",
+          "Socket Designation": "CPU 1",
+          "Type": "Central Processor",
+          "Family": "Other",
+          "Manufacturer": "Intel",
+          "ID": "E4 06 03 00 FF FB 89 17",
+          "Version": "Not Specified",
+          "Voltage": "Unknown",
+          "External Clock": "Unknown",
+          "Max Speed": "2500 MHz",
+          "Current Speed": "2500 MHz",
+          "Status": "Populated, Enabled",
+          "Upgrade": "Other"
+        }
+      ],
+      "socket_designation": "CPU 1",
+      "type": "Central Processor",
+      "family": "Other",
+      "manufacturer": "Intel",
+      "id": "E4 06 03 00 FF FB 89 17",
+      "version": "Not Specified",
+      "voltage": "Unknown",
+      "external_clock": "Unknown",
+      "max_speed": "2500 MHz",
+      "current_speed": "2500 MHz",
+      "status": "Populated, Enabled",
+      "upgrade": "Other"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "0x0B00",
+          "size": "11",
+          "application_identifier": "End Of Table",
+          "String 1": "Xen",
+          "Location": "Other",
+          "Use": "System Memory",
+          "Error Correction Type": "Multi-bit ECC",
+          "Maximum Capacity": "1 GB",
+          "Error Information Handle": "0x0000",
+          "Number Of Devices": "1",
+          "Array Handle": "0x1000",
+          "Total Width": "64 bits",
+          "Data Width": "64 bits",
+          "Size": "1024 MB",
+          "Form Factor": "DIMM",
+          "Set": "None",
+          "Locator": "DIMM 0",
+          "Bank Locator": "Not Specified",
+          "Type": "RAM",
+          "Type Detail": "None",
+          "Starting Address": "0x00000000000",
+          "Ending Address": "0x0003FFFFFFF",
+          "Range Size": "1 GB",
+          "Physical Array Handle": "0x1000",
+          "Partition Width": "1",
+          "Physical Device Handle": "0x1100",
+          "Memory Array Mapped Address Handle": "0x1300",
+          "Partition Row Position": "1",
+          "Status": "No errors detected"
+        }
+      ],
+      "string_1": "Xen",
+      "location": "Other",
+      "use": "System Memory",
+      "error_correction_type": "Multi-bit ECC",
+      "maximum_capacity": "1 GB",
+      "error_information_handle": "0x0000",
+      "number_of_devices": "1",
+      "array_handle": "0x1000",
+      "total_width": "64 bits",
+      "data_width": "64 bits",
+      "size": "1024 MB",
+      "form_factor": "DIMM",
+      "set": "None",
+      "locator": "DIMM 0",
+      "bank_locator": "Not Specified",
+      "type": "RAM",
+      "type_detail": "None",
+      "starting_address": "0x00000000000",
+      "ending_address": "0x0003FFFFFFF",
+      "range_size": "1 GB",
+      "physical_array_handle": "0x1000",
+      "partition_width": "1",
+      "physical_device_handle": "0x1100",
+      "memory_array_mapped_address_handle": "0x1300",
+      "partition_row_position": "1",
+      "status": "No errors detected"
+    }
+  },
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-linux-gnu",
+      "version": "2.1.3",
+      "release_date": "2014-09-19",
+      "target": "x86_64-suse-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "suse",
+      "target_os": "linux-gnu",
+      "host": "x86_64-suse-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux-gnu",
+      "host_vendor": "suse",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gems_dir": "/usr/local/gems",
+      "gem_bin": "/usr/local/bin/gem"
+    },
+    "powershell": null
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "12.2.1",
+      "chef_root": "/usr/local/gems/chef-12.2.1/lib"
+    },
+    "ohai": {
+      "version": "8.2.0",
+      "ohai_root": "/usr/local/gems/ohai-8.2.0/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "settings": {
+    },
+    "interfaces": {
+      "eth0": {
+        "addresses": {
+          "10.0.0.2": {
+            "broadcast": "10.0.0.255",
+            "family": "inet",
+            "netmask": "255.255.255.0",
+            "prefixlen": "23",
+            "scope": "Global"
+          }
+        },
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "encapsulation": "Ethernet",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "1500",
+        "number": "0",
+        "routes": {
+          "10.0.0.0/255": {
+            "scope": "link",
+            "src": "10.0.0.2"
+          }
+        },
+        "state": "up",
+        "type": "eth"
+      }
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "cpu": {
+    "real": 1,
+    "total": 1
+  },
+  "memory": {
+    "total": "1024MB"
+  }
+}


### PR DESCRIPTION
add output from running fauxhai on an opensuse 13.2 installation. 