### PR TITLE
Add debian 8.0 and  debian 8.1

### DIFF
--- a/lib/fauxhai/platforms/debian/8.0.json
+++ b/lib/fauxhai/platforms/debian/8.0.json
@@ -1,0 +1,681 @@
+{
+  "kernel": {
+    "name": "Linux",
+    "release": "3.16.0-4-amd64",
+    "version": "#1 SMP Debian 3.16.7-ckt11-1 (2015-05-24)",
+    "machine": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "nfsv3": {
+        "size": "37551",
+        "refcount": "1"
+      },
+      "vboxsf": {
+        "size": "41446",
+        "refcount": "0"
+      },
+      "nfsd": {
+        "size": "263032",
+        "refcount": "2"
+      },
+      "auth_rpcgss": {
+        "size": "51211",
+        "refcount": "1"
+      },
+      "oid_registry": {
+        "size": "12419",
+        "refcount": "1"
+      },
+      "nfs_acl": {
+        "size": "12511",
+        "refcount": "2"
+      },
+      "nfs": {
+        "size": "188136",
+        "refcount": "2"
+      },
+      "lockd": {
+        "size": "83389",
+        "refcount": "3"
+      },
+      "fscache": {
+        "size": "45542",
+        "refcount": "1"
+      },
+      "sunrpc": {
+        "size": "237402",
+        "refcount": "10"
+      },
+      "vboxvideo": {
+        "size": "12437",
+        "refcount": "0"
+      },
+      "drm": {
+        "size": "249955",
+        "refcount": "2"
+      },
+      "ppdev": {
+        "size": "16782",
+        "refcount": "0"
+      },
+      "evdev": {
+        "size": "17445",
+        "refcount": "7"
+      },
+      "i2c_piix4": {
+        "size": "20864",
+        "refcount": "0"
+      },
+      "i2c_core": {
+        "size": "46012",
+        "refcount": "2"
+      },
+      "psmouse": {
+        "size": "99249",
+        "refcount": "0"
+      },
+      "pcspkr": {
+        "size": "12595",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "12849",
+        "refcount": "0"
+      },
+      "parport_pc": {
+        "size": "26300",
+        "refcount": "0"
+      },
+      "parport": {
+        "size": "35749",
+        "refcount": "2"
+      },
+      "processor": {
+        "size": "28221",
+        "refcount": "0"
+      },
+      "battery": {
+        "size": "13356",
+        "refcount": "0"
+      },
+      "button": {
+        "size": "12944",
+        "refcount": "0"
+      },
+      "vboxguest": {
+        "size": "193979",
+        "refcount": "2"
+      },
+      "video": {
+        "size": "18096",
+        "refcount": "0"
+      },
+      "ac": {
+        "size": "12715",
+        "refcount": "0"
+      },
+      "thermal_sys": {
+        "size": "27642",
+        "refcount": "2"
+      },
+      "autofs4": {
+        "size": "35529",
+        "refcount": "2"
+      },
+      "ext4": {
+        "size": "473802",
+        "refcount": "2"
+      },
+      "crc16": {
+        "size": "12343",
+        "refcount": "1"
+      },
+      "mbcache": {
+        "size": "17171",
+        "refcount": "1"
+      },
+      "jbd2": {
+        "size": "82413",
+        "refcount": "1"
+      },
+      "dm_mod": {
+        "size": "89405",
+        "refcount": "6"
+      },
+      "sg": {
+        "size": "29973",
+        "refcount": "0"
+      },
+      "sd_mod": {
+        "size": "44356",
+        "refcount": "3"
+      },
+      "crc_t10dif": {
+        "size": "12431",
+        "refcount": "1"
+      },
+      "crct10dif_generic": {
+        "size": "12581",
+        "refcount": "1"
+      },
+      "crct10dif_common": {
+        "size": "12356",
+        "refcount": "2"
+      },
+      "ata_generic": {
+        "size": "12490",
+        "refcount": "0"
+      },
+      "ahci": {
+        "size": "33291",
+        "refcount": "2"
+      },
+      "ata_piix": {
+        "size": "33592",
+        "refcount": "0"
+      },
+      "libahci": {
+        "size": "27158",
+        "refcount": "1"
+      },
+      "libata": {
+        "size": "177457",
+        "refcount": "4"
+      },
+      "scsi_mod": {
+        "size": "191405",
+        "refcount": "3"
+      },
+      "e1000": {
+        "size": "122545",
+        "refcount": "0"
+      }
+    }
+  },
+  "lsb": {
+    "id": "Debian",
+    "description": "Debian GNU/Linux 8.0 (jessie)",
+    "release": "8.0",
+    "codename": "jessie"
+  },
+  "os": "linux",
+  "os_version": "3.16.0-4-amd64",
+  "platform": "debian",
+  "platform_version": "8.0",
+  "platform_family": "debian",
+  "filesystem": {
+    "/dev/dm-0": {
+      "kb_size": "40129116",
+      "kb_used": "1939132",
+      "kb_available": "36128468",
+      "percent_used": "6%",
+      "mount": "/",
+      "total_inodes": "2559088",
+      "inodes_used": "112457",
+      "inodes_available": "2446631",
+      "inodes_percent_used": "5%"
+    },
+    "udev": {
+      "kb_size": "10240",
+      "kb_used": "0",
+      "kb_available": "10240",
+      "percent_used": "0%",
+      "mount": "/dev",
+      "total_inodes": "255086",
+      "inodes_used": "313",
+      "inodes_available": "254773",
+      "inodes_percent_used": "1%",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "size=10240k",
+        "nr_inodes=255086",
+        "mode=755"
+      ]
+    },
+    "tmpfs": {
+      "kb_size": "1029180",
+      "kb_used": "0",
+      "kb_available": "1029180",
+      "percent_used": "0%",
+      "mount": "/sys/fs/cgroup",
+      "total_inodes": "257295",
+      "inodes_used": "13",
+      "inodes_available": "257282",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ]
+    },
+    "/dev/sda1": {
+      "kb_size": "240972",
+      "kb_used": "33262",
+      "kb_available": "195269",
+      "percent_used": "15%",
+      "mount": "/boot",
+      "total_inodes": "62248",
+      "inodes_used": "328",
+      "inodes_available": "61920",
+      "inodes_percent_used": "1%",
+      "fs_type": "ext2",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ],
+      "uuid": "db6efb51-8ffb-49de-ba9f-4641e2842d7b"
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ]
+    },
+    "/dev/mapper/packer--debian--8--vg-root": {
+      "mount": "/",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "errors=remount-ro",
+        "data=ordered"
+      ],
+      "uuid": "1464d732-14fb-4168-8a39-188763d801b6"
+    },
+    "securityfs": {
+      "mount": "/sys/kernel/security",
+      "fs_type": "securityfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "cgroup": {
+      "mount": "/sys/fs/cgroup/perf_event",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "perf_event"
+      ]
+    },
+    "pstore": {
+      "mount": "/sys/fs/pstore",
+      "fs_type": "pstore",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "systemd-1": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "autofs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "fd=22",
+        "pgrp=1",
+        "timeout=300",
+        "minproto=5",
+        "maxproto=5",
+        "direct"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "mqueue": {
+      "mount": "/dev/mqueue",
+      "fs_type": "mqueue",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "hugetlbfs": {
+      "mount": "/dev/hugepages",
+      "fs_type": "hugetlbfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "rpc_pipefs": {
+      "mount": "/run/rpc_pipefs",
+      "fs_type": "rpc_pipefs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "/dev/sda5": {
+      "fs_type": "LVM2_member",
+      "uuid": "j0Gb1U-h0DL-nYcZ-ADE1-SzmB-d635-TwCah9"
+    },
+    "/dev/mapper/packer--debian--8--vg-swap_1": {
+      "fs_type": "swap",
+      "uuid": "0da1d226-246f-4b56-a55a-b5dc28835b0a"
+    },
+    "rootfs": {
+      "mount": "/",
+      "fs_type": "rootfs",
+      "mount_options": [
+        "rw"
+      ]
+    }
+  },
+  "dmi": {
+    "dmidecode_version": "2.12",
+    "smbios_version": "2.5",
+    "structures": {
+      "count": "10",
+      "size": "450"
+    },
+    "table_location": "0x000E1000",
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "innotek GmbH",
+          "Version": "VirtualBox",
+          "Release Date": "12/01/2006",
+          "Address": "0xE0000",
+          "Runtime Size": "128 kB",
+          "ROM Size": "128 kB",
+          "Characteristics": {
+            "ISA is supported": null,
+            "PCI is supported": null,
+            "Boot from CD is supported": null,
+            "Selectable boot is supported": null,
+            "8042 keyboard services are supported (int 9h)": null,
+            "CGA/mono video services are supported (int 10h)": null,
+            "ACPI is supported": null
+          }
+        }
+      ],
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox",
+      "release_date": "12/01/2006",
+      "address": "0xE0000",
+      "runtime_size": "128 kB",
+      "rom_size": "128 kB"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0001",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "innotek GmbH",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "UUID": "99F44755-64AA-4DB4-A63E-DA68B70CEE3C",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Virtual Machine"
+        }
+      ],
+      "manufacturer": "innotek GmbH",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "uuid": "99F44755-64AA-4DB4-A63E-DA68B70CEE3C",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Virtual Machine"
+    },
+    "base_board": {
+      "all_records": [
+        {
+          "record_id": "0x0008",
+          "size": "2",
+          "application_identifier": "Base Board Information",
+          "Manufacturer": "Oracle Corporation",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "Asset Tag": "Not Specified",
+          "Features": {
+            "Board is a hosting board": null
+          },
+          "Location In Chassis": "Not Specified",
+          "Chassis Handle": "0x0003",
+          "Type": "Motherboard",
+          "Contained Object Handles": "0"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "asset_tag": "Not Specified",
+      "location_in_chassis": "Not Specified",
+      "chassis_handle": "0x0003",
+      "type": "Motherboard",
+      "contained_object_handles": "0"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0003",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Oracle Corporation",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "None"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "Not Specified",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "None"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "0x0002",
+          "size": "11",
+          "application_identifier": "OEM Strings",
+          "String 1": "vboxVer_4.3.28",
+          "String 2": "vboxRev_100309"
+        }
+      ],
+      "string_1": "vboxVer_4.3.28",
+      "string_2": "vboxRev_100309"
+    }
+  },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "ohai_time": 1435832392.9402292,
+  "languages": {
+    "ruby": {
+      "bin_dir": "/usr/local/bin",
+      "gem_bin": "/usr/local/bin/gem",
+      "gems_dir": "/usr/local/gems",
+      "ruby_bin": "/usr/local/bin/ruby"
+    },
+    "powershell": null
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "12.3.0",
+      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+    },
+    "ohai": {
+      "version": "8.4.0",
+      "ohai_root": "/usr/local/gems/ohai-8.4.0/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "settings": {
+    },
+    "interfaces": {
+      "eth0": {
+        "addresses": {
+          "10.0.0.2": {
+            "broadcast": "10.0.0.255",
+            "family": "inet",
+            "netmask": "255.255.255.0",
+            "prefixlen": "23",
+            "scope": "Global"
+          }
+        },
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "encapsulation": "Ethernet",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "1500",
+        "number": "0",
+        "routes": {
+          "10.0.0.0/255": {
+            "scope": "link",
+            "src": "10.0.0.2"
+          }
+        },
+        "state": "up",
+        "type": "eth"
+      }
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "cpu": {
+    "real": 1,
+    "total": 1
+  },
+  "memory": {
+    "total": "1024MB"
+  }
+}

--- a/lib/fauxhai/platforms/debian/8.1.json
+++ b/lib/fauxhai/platforms/debian/8.1.json
@@ -1,0 +1,681 @@
+{
+  "kernel": {
+    "name": "Linux",
+    "release": "3.16.0-4-amd64",
+    "version": "#1 SMP Debian 3.16.7-ckt11-1 (2015-05-24)",
+    "machine": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "nfsv3": {
+        "size": "37551",
+        "refcount": "1"
+      },
+      "vboxsf": {
+        "size": "41446",
+        "refcount": "0"
+      },
+      "nfsd": {
+        "size": "263032",
+        "refcount": "2"
+      },
+      "auth_rpcgss": {
+        "size": "51211",
+        "refcount": "1"
+      },
+      "oid_registry": {
+        "size": "12419",
+        "refcount": "1"
+      },
+      "nfs_acl": {
+        "size": "12511",
+        "refcount": "2"
+      },
+      "nfs": {
+        "size": "188136",
+        "refcount": "2"
+      },
+      "lockd": {
+        "size": "83389",
+        "refcount": "3"
+      },
+      "fscache": {
+        "size": "45542",
+        "refcount": "1"
+      },
+      "sunrpc": {
+        "size": "237402",
+        "refcount": "10"
+      },
+      "vboxvideo": {
+        "size": "12437",
+        "refcount": "0"
+      },
+      "drm": {
+        "size": "249955",
+        "refcount": "2"
+      },
+      "ppdev": {
+        "size": "16782",
+        "refcount": "0"
+      },
+      "evdev": {
+        "size": "17445",
+        "refcount": "7"
+      },
+      "i2c_piix4": {
+        "size": "20864",
+        "refcount": "0"
+      },
+      "i2c_core": {
+        "size": "46012",
+        "refcount": "2"
+      },
+      "psmouse": {
+        "size": "99249",
+        "refcount": "0"
+      },
+      "pcspkr": {
+        "size": "12595",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "12849",
+        "refcount": "0"
+      },
+      "parport_pc": {
+        "size": "26300",
+        "refcount": "0"
+      },
+      "parport": {
+        "size": "35749",
+        "refcount": "2"
+      },
+      "processor": {
+        "size": "28221",
+        "refcount": "0"
+      },
+      "battery": {
+        "size": "13356",
+        "refcount": "0"
+      },
+      "button": {
+        "size": "12944",
+        "refcount": "0"
+      },
+      "vboxguest": {
+        "size": "193979",
+        "refcount": "2"
+      },
+      "video": {
+        "size": "18096",
+        "refcount": "0"
+      },
+      "ac": {
+        "size": "12715",
+        "refcount": "0"
+      },
+      "thermal_sys": {
+        "size": "27642",
+        "refcount": "2"
+      },
+      "autofs4": {
+        "size": "35529",
+        "refcount": "2"
+      },
+      "ext4": {
+        "size": "473802",
+        "refcount": "2"
+      },
+      "crc16": {
+        "size": "12343",
+        "refcount": "1"
+      },
+      "mbcache": {
+        "size": "17171",
+        "refcount": "1"
+      },
+      "jbd2": {
+        "size": "82413",
+        "refcount": "1"
+      },
+      "dm_mod": {
+        "size": "89405",
+        "refcount": "6"
+      },
+      "sg": {
+        "size": "29973",
+        "refcount": "0"
+      },
+      "sd_mod": {
+        "size": "44356",
+        "refcount": "3"
+      },
+      "crc_t10dif": {
+        "size": "12431",
+        "refcount": "1"
+      },
+      "crct10dif_generic": {
+        "size": "12581",
+        "refcount": "1"
+      },
+      "crct10dif_common": {
+        "size": "12356",
+        "refcount": "2"
+      },
+      "ata_generic": {
+        "size": "12490",
+        "refcount": "0"
+      },
+      "ahci": {
+        "size": "33291",
+        "refcount": "2"
+      },
+      "ata_piix": {
+        "size": "33592",
+        "refcount": "0"
+      },
+      "libahci": {
+        "size": "27158",
+        "refcount": "1"
+      },
+      "libata": {
+        "size": "177457",
+        "refcount": "4"
+      },
+      "scsi_mod": {
+        "size": "191405",
+        "refcount": "3"
+      },
+      "e1000": {
+        "size": "122545",
+        "refcount": "0"
+      }
+    }
+  },
+  "lsb": {
+    "id": "Debian",
+    "description": "Debian GNU/Linux 8.1 (jessie)",
+    "release": "8.1",
+    "codename": "jessie"
+  },
+  "os": "linux",
+  "os_version": "3.16.0-4-amd64",
+  "platform": "debian",
+  "platform_version": "8.1",
+  "platform_family": "debian",
+  "filesystem": {
+    "/dev/dm-0": {
+      "kb_size": "40129116",
+      "kb_used": "1939132",
+      "kb_available": "36128468",
+      "percent_used": "6%",
+      "mount": "/",
+      "total_inodes": "2559088",
+      "inodes_used": "112457",
+      "inodes_available": "2446631",
+      "inodes_percent_used": "5%"
+    },
+    "udev": {
+      "kb_size": "10240",
+      "kb_used": "0",
+      "kb_available": "10240",
+      "percent_used": "0%",
+      "mount": "/dev",
+      "total_inodes": "255086",
+      "inodes_used": "313",
+      "inodes_available": "254773",
+      "inodes_percent_used": "1%",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "size=10240k",
+        "nr_inodes=255086",
+        "mode=755"
+      ]
+    },
+    "tmpfs": {
+      "kb_size": "1029180",
+      "kb_used": "0",
+      "kb_available": "1029180",
+      "percent_used": "0%",
+      "mount": "/sys/fs/cgroup",
+      "total_inodes": "257295",
+      "inodes_used": "13",
+      "inodes_available": "257282",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "ro",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ]
+    },
+    "/dev/sda1": {
+      "kb_size": "240972",
+      "kb_used": "33262",
+      "kb_available": "195269",
+      "percent_used": "15%",
+      "mount": "/boot",
+      "total_inodes": "62248",
+      "inodes_used": "328",
+      "inodes_available": "61920",
+      "inodes_percent_used": "1%",
+      "fs_type": "ext2",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ],
+      "uuid": "db6efb51-8ffb-49de-ba9f-4641e2842d7b"
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ]
+    },
+    "/dev/mapper/packer--debian--8--vg-root": {
+      "mount": "/",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "errors=remount-ro",
+        "data=ordered"
+      ],
+      "uuid": "1464d732-14fb-4168-8a39-188763d801b6"
+    },
+    "securityfs": {
+      "mount": "/sys/kernel/security",
+      "fs_type": "securityfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "cgroup": {
+      "mount": "/sys/fs/cgroup/perf_event",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "perf_event"
+      ]
+    },
+    "pstore": {
+      "mount": "/sys/fs/pstore",
+      "fs_type": "pstore",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "systemd-1": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "autofs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "fd=22",
+        "pgrp=1",
+        "timeout=300",
+        "minproto=5",
+        "maxproto=5",
+        "direct"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "mqueue": {
+      "mount": "/dev/mqueue",
+      "fs_type": "mqueue",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "hugetlbfs": {
+      "mount": "/dev/hugepages",
+      "fs_type": "hugetlbfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "rpc_pipefs": {
+      "mount": "/run/rpc_pipefs",
+      "fs_type": "rpc_pipefs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "/dev/sda5": {
+      "fs_type": "LVM2_member",
+      "uuid": "j0Gb1U-h0DL-nYcZ-ADE1-SzmB-d635-TwCah9"
+    },
+    "/dev/mapper/packer--debian--8--vg-swap_1": {
+      "fs_type": "swap",
+      "uuid": "0da1d226-246f-4b56-a55a-b5dc28835b0a"
+    },
+    "rootfs": {
+      "mount": "/",
+      "fs_type": "rootfs",
+      "mount_options": [
+        "rw"
+      ]
+    }
+  },
+  "dmi": {
+    "dmidecode_version": "2.12",
+    "smbios_version": "2.5",
+    "structures": {
+      "count": "10",
+      "size": "450"
+    },
+    "table_location": "0x000E1000",
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "innotek GmbH",
+          "Version": "VirtualBox",
+          "Release Date": "12/01/2006",
+          "Address": "0xE0000",
+          "Runtime Size": "128 kB",
+          "ROM Size": "128 kB",
+          "Characteristics": {
+            "ISA is supported": null,
+            "PCI is supported": null,
+            "Boot from CD is supported": null,
+            "Selectable boot is supported": null,
+            "8042 keyboard services are supported (int 9h)": null,
+            "CGA/mono video services are supported (int 10h)": null,
+            "ACPI is supported": null
+          }
+        }
+      ],
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox",
+      "release_date": "12/01/2006",
+      "address": "0xE0000",
+      "runtime_size": "128 kB",
+      "rom_size": "128 kB"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0001",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "innotek GmbH",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "UUID": "99F44755-64AA-4DB4-A63E-DA68B70CEE3C",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Virtual Machine"
+        }
+      ],
+      "manufacturer": "innotek GmbH",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "uuid": "99F44755-64AA-4DB4-A63E-DA68B70CEE3C",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Virtual Machine"
+    },
+    "base_board": {
+      "all_records": [
+        {
+          "record_id": "0x0008",
+          "size": "2",
+          "application_identifier": "Base Board Information",
+          "Manufacturer": "Oracle Corporation",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "Asset Tag": "Not Specified",
+          "Features": {
+            "Board is a hosting board": null
+          },
+          "Location In Chassis": "Not Specified",
+          "Chassis Handle": "0x0003",
+          "Type": "Motherboard",
+          "Contained Object Handles": "0"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "asset_tag": "Not Specified",
+      "location_in_chassis": "Not Specified",
+      "chassis_handle": "0x0003",
+      "type": "Motherboard",
+      "contained_object_handles": "0"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0003",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Oracle Corporation",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "None"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "Not Specified",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "None"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "0x0002",
+          "size": "11",
+          "application_identifier": "OEM Strings",
+          "String 1": "vboxVer_4.3.28",
+          "String 2": "vboxRev_100309"
+        }
+      ],
+      "string_1": "vboxVer_4.3.28",
+      "string_2": "vboxRev_100309"
+    }
+  },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "ohai_time": 1435832392.9402292,
+  "languages": {
+    "ruby": {
+      "bin_dir": "/usr/local/bin",
+      "gem_bin": "/usr/local/bin/gem",
+      "gems_dir": "/usr/local/gems",
+      "ruby_bin": "/usr/local/bin/ruby"
+    },
+    "powershell": null
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "12.3.0",
+      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+    },
+    "ohai": {
+      "version": "8.4.0",
+      "ohai_root": "/usr/local/gems/ohai-8.4.0/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "settings": {
+    },
+    "interfaces": {
+      "eth0": {
+        "addresses": {
+          "10.0.0.2": {
+            "broadcast": "10.0.0.255",
+            "family": "inet",
+            "netmask": "255.255.255.0",
+            "prefixlen": "23",
+            "scope": "Global"
+          }
+        },
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "encapsulation": "Ethernet",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "1500",
+        "number": "0",
+        "routes": {
+          "10.0.0.0/255": {
+            "scope": "link",
+            "src": "10.0.0.2"
+          }
+        },
+        "state": "up",
+        "type": "eth"
+      }
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "cpu": {
+    "real": 1,
+    "total": 1
+  },
+  "memory": {
+    "total": "1024MB"
+  }
+}


### PR DESCRIPTION
fixes #149 

note: because the 8.0 bento box seems already to be 8.1 I've manually changed the version numbers on the `8.0.json` down to `8.0`.