### PR TITLE
Add missing platform data for Solaris2

### DIFF
--- a/lib/fauxhai/platforms/solaris2/5.11.json
+++ b/lib/fauxhai/platforms/solaris2/5.11.json
@@ -1038,6 +1038,7 @@
   "os_version": "5.11",
   "platform_version": "5.11",
   "platform_build": "11.1",
+  "platform": "solaris2",
   "platform_family": "solaris2",
   "filesystem": {
     "rpool/ROOT/solaris": {


### PR DESCRIPTION
Not sure why `platform` is missing but it’s returned by real Ohai:

```
-bash-3.2$ ohai | grep platform
  "platform_version": "5.10",
  "platform_build": "Generic_147148-26",
  "platform": "solaris2",
  "platform_family": "solaris2",
```