### PR TITLE
Add centos-6.7 platform support

### DIFF
--- a/lib/fauxhai/platforms/centos/6.7.json
+++ b/lib/fauxhai/platforms/centos/6.7.json
@@ -1,0 +1,471 @@
+{
+  "kernel": {
+    "name": "Linux",
+    "release": "2.6.32-573.el6.x86_64",
+    "version": "#1 SMP Thu Jul 23 15:44:03 UTC 2015",
+    "machine": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "ip6t_REJECT": {
+        "size": "4340",
+        "refcount": "1"
+      },
+      "nf_conntrack_ipv6": {
+        "size": "7985",
+        "refcount": "1"
+      },
+      "nf_defrag_ipv6": {
+        "size": "26468",
+        "refcount": "1"
+      },
+      "ip6table_filter": {
+        "size": "2889",
+        "refcount": "1"
+      },
+      "ip6_tables": {
+        "size": "18732",
+        "refcount": "1"
+      },
+      "nf_conntrack_ipv4": {
+        "size": "9154",
+        "refcount": "1"
+      },
+      "nf_defrag_ipv4": {
+        "size": "1483",
+        "refcount": "1"
+      },
+      "xt_state": {
+        "size": "1492",
+        "refcount": "2"
+      },
+      "nf_conntrack": {
+        "size": "79206",
+        "refcount": "3"
+      },
+      "ipt_REJECT": {
+        "size": "2351",
+        "refcount": "2"
+      },
+      "xt_comment": {
+        "size": "1034",
+        "refcount": "25"
+      },
+      "xt_multiport": {
+        "size": "2700",
+        "refcount": "20"
+      },
+      "iptable_filter": {
+        "size": "2793",
+        "refcount": "1"
+      },
+      "ip_tables": {
+        "size": "17831",
+        "refcount": "1"
+      },
+      "nfs": {
+        "size": "431044",
+        "refcount": "1"
+      },
+      "fscache": {
+        "size": "55636",
+        "refcount": "1"
+      },
+      "nfsd": {
+        "size": "311382",
+        "refcount": "13"
+      },
+      "lockd": {
+        "size": "73694",
+        "refcount": "2"
+      },
+      "nfs_acl": {
+        "size": "2647",
+        "refcount": "2"
+      },
+      "auth_rpcgss": {
+        "size": "46084",
+        "refcount": "2"
+      },
+      "sunrpc": {
+        "size": "266331",
+        "refcount": "22"
+      },
+      "exportfs": {
+        "size": "4236",
+        "refcount": "1"
+      },
+      "vboxsf": {
+        "size": "37727",
+        "refcount": "0"
+      },
+      "ipv6": {
+        "size": "335589",
+        "refcount": "47"
+      },
+      "ppdev": {
+        "size": "8217",
+        "refcount": "0"
+      },
+      "parport_pc": {
+        "size": "22658",
+        "refcount": "0"
+      },
+      "parport": {
+        "size": "36209",
+        "refcount": "2"
+      },
+      "sg": {
+        "size": "29318",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "4626",
+        "refcount": "0"
+      },
+      "i2c_piix4": {
+        "size": "11232",
+        "refcount": "0"
+      },
+      "i2c_core": {
+        "size": "29132",
+        "refcount": "1"
+      },
+      "vboxguest": {
+        "size": "284698",
+        "refcount": "2"
+      },
+      "e1000": {
+        "size": "134876",
+        "refcount": "0"
+      },
+      "ext4": {
+        "size": "378683",
+        "refcount": "2"
+      },
+      "jbd2": {
+        "size": "93252",
+        "refcount": "1"
+      },
+      "mbcache": {
+        "size": "8193",
+        "refcount": "1"
+      },
+      "video": {
+        "size": "21654",
+        "refcount": "0"
+      },
+      "output": {
+        "size": "2409",
+        "refcount": "1"
+      },
+      "sd_mod": {
+        "size": "37030",
+        "refcount": "3"
+      },
+      "crc_t10dif": {
+        "size": "1209",
+        "refcount": "1"
+      },
+      "ahci": {
+        "size": "42738",
+        "refcount": "2"
+      },
+      "pata_acpi": {
+        "size": "3701",
+        "refcount": "0"
+      },
+      "ata_generic": {
+        "size": "3837",
+        "refcount": "0"
+      },
+      "ata_piix": {
+        "size": "24409",
+        "refcount": "0"
+      },
+      "dm_mirror": {
+        "size": "14384",
+        "refcount": "0"
+      },
+      "dm_region_hash": {
+        "size": "12085",
+        "refcount": "1"
+      },
+      "dm_log": {
+        "size": "9930",
+        "refcount": "2"
+      },
+      "dm_mod": {
+        "size": "99200",
+        "refcount": "8"
+      }
+    }
+  },
+  "os": "linux",
+  "os_version": "2.6.32-573.el6.x86_64",
+  "lsb": {
+  },
+  "platform": "centos",
+  "platform_version": "6.7",
+  "platform_family": "rhel",
+  "filesystem": {
+    "/dev/mapper/VolGroup-lv_root": {
+      "kb_size": "39710104",
+      "kb_used": "859892",
+      "kb_available": "36826380",
+      "percent_used": "3%",
+      "mount": "/",
+      "total_inodes": "2531328",
+      "inodes_used": "30369",
+      "inodes_available": "2500959",
+      "inodes_percent_used": "2%",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw"
+      ],
+      "uuid": "d78ffc3c-a7b3-4836-8f9b-99b480d52203"
+    },
+    "tmpfs": {
+      "kb_size": "234640",
+      "kb_used": "0",
+      "kb_available": "234640",
+      "percent_used": "0%",
+      "mount": "/dev/shm",
+      "total_inodes": "58660",
+      "inodes_used": "1",
+      "inodes_available": "58659",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "rootcontext=\"system_u:object_r:tmpfs_t:s0\""
+      ]
+    },
+    "/dev/sda1": {
+      "kb_size": "487652",
+      "kb_used": "29794",
+      "kb_available": "432258",
+      "percent_used": "7%",
+      "mount": "/boot",
+      "total_inodes": "128016",
+      "inodes_used": "38",
+      "inodes_available": "127978",
+      "inodes_percent_used": "1%",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw"
+      ],
+      "uuid": "f8314c9a-92d0-4b56-93bc-d5096cbda073"
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw"
+      ]
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "gid=5",
+        "mode=620"
+      ]
+    },
+    "none": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "binfmt_misc",
+      "mount_options": [
+        "rw"
+      ]
+    },
+    "sunrpc": {
+      "mount": "/var/lib/nfs/rpc_pipefs",
+      "fs_type": "rpc_pipefs",
+      "mount_options": [
+        "rw"
+      ]
+    },
+    "nfsd": {
+      "mount": "/proc/fs/nfsd",
+      "fs_type": "nfsd",
+      "mount_options": [
+        "rw"
+      ]
+    },
+    "/dev/sda2": {
+      "fs_type": "LVM2_member",
+      "uuid": "1m7In2-cfkY-2wa7-JNuC-4vPt-UGyA-Vu1byZ"
+    },
+    "/dev/mapper/VolGroup-lv_swap": {
+      "fs_type": "swap",
+      "uuid": "1e826a91-83ef-4070-8433-0e2d5508bee0"
+    },
+    "rootfs": {
+      "mount": "/",
+      "fs_type": "rootfs",
+      "mount_options": [
+        "rw"
+      ]
+    },
+    "devtmpfs": {
+      "mount": "/dev",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "size=222832k",
+        "nr_inodes=55708",
+        "mode=755"
+      ]
+    },
+    "/proc/bus/usb": {
+      "mount": "/proc/bus/usb",
+      "fs_type": "usbfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    }
+  },
+  "dmi": {
+  },
+  "ohai_time": 1444223221.0411744,
+  "command": {
+    "ps": "ps -ef"
+  },
+  "languages": {
+    "ruby": {
+      "bin_dir": "/usr/local/bin",
+      "gem_bin": "/usr/local/bin/gem",
+      "gems_dir": "/usr/local/gems",
+      "ruby_bin": "/usr/local/bin/ruby"
+    },
+    "powershell": null
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "12.4.3",
+      "chef_root": "/usr/local/gems/chef-12.4.3/lib"
+    },
+    "ohai": {
+      "version": "8.5.1",
+      "ohai_root": "/usr/local/gems/ohai-8.5.1/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "settings": {
+    },
+    "interfaces": {
+      "eth0": {
+        "addresses": {
+          "10.0.0.2": {
+            "broadcast": "10.0.0.255",
+            "family": "inet",
+            "netmask": "255.255.255.0",
+            "prefixlen": "23",
+            "scope": "Global"
+          }
+        },
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "encapsulation": "Ethernet",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "1500",
+        "number": "0",
+        "routes": {
+          "10.0.0.0/255": {
+            "scope": "link",
+            "src": "10.0.0.2"
+          }
+        },
+        "state": "up",
+        "type": "eth"
+      }
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "cpu": {
+    "real": 1,
+    "total": 1
+  },
+  "memory": {
+    "total": "1024MB"
+  }
+}


### PR DESCRIPTION
Introduce fauxhai data for CentOS 6.7. Compared to 6.5 and previous platform versions, the .json I'm submitting is very very similar. 6.6 seems to be somewhat of an anomaly for the existing platform data.

Fixes #163.