### PR TITLE
Update Fedora 21/22 and Ubuntu 12.04/14.04

### DIFF
--- a/lib/fauxhai/platforms/fedora/21.json
+++ b/lib/fauxhai/platforms/fedora/21.json
@@ -6,9 +6,17 @@
     "machine": "x86_64",
     "os": "GNU/Linux",
     "modules": {
-      "vboxsf": {
-        "size": "39595",
-        "refcount": "0"
+      "ip6t_rpfilter": {
+        "size": "12546",
+        "refcount": "1"
+      },
+      "ip6t_REJECT": {
+        "size": "12939",
+        "refcount": "2"
+      },
+      "xt_conntrack": {
+        "size": "12760",
+        "refcount": "9"
       },
       "cfg80211": {
         "size": "505401",
@@ -18,13 +26,145 @@
         "size": "21980",
         "refcount": "1"
       },
-      "snd_pcsp": {
-        "size": "14703",
+      "ebtable_nat": {
+        "size": "12807",
         "refcount": "0"
+      },
+      "ebtable_broute": {
+        "size": "12731",
+        "refcount": "0"
+      },
+      "bridge": {
+        "size": "116093",
+        "refcount": "1"
+      },
+      "stp": {
+        "size": "12868",
+        "refcount": "1"
+      },
+      "llc": {
+        "size": "13941",
+        "refcount": "2"
+      },
+      "ebtable_filter": {
+        "size": "12827",
+        "refcount": "0"
+      },
+      "ebtables": {
+        "size": "30758",
+        "refcount": "3"
+      },
+      "ip6table_nat": {
+        "size": "12974",
+        "refcount": "1"
+      },
+      "nf_conntrack_ipv6": {
+        "size": "18738",
+        "refcount": "6"
+      },
+      "nf_defrag_ipv6": {
+        "size": "34786",
+        "refcount": "1"
+      },
+      "nf_nat_ipv6": {
+        "size": "13213",
+        "refcount": "1"
+      },
+      "ip6table_mangle": {
+        "size": "12700",
+        "refcount": "1"
+      },
+      "ip6table_security": {
+        "size": "12710",
+        "refcount": "1"
+      },
+      "ip6table_raw": {
+        "size": "12683",
+        "refcount": "1"
+      },
+      "ip6table_filter": {
+        "size": "12815",
+        "refcount": "1"
+      },
+      "ip6_tables": {
+        "size": "26809",
+        "refcount": "5"
+      },
+      "iptable_nat": {
+        "size": "12970",
+        "refcount": "1"
+      },
+      "nf_conntrack_ipv4": {
+        "size": "14656",
+        "refcount": "5"
+      },
+      "nf_defrag_ipv4": {
+        "size": "12702",
+        "refcount": "1"
+      },
+      "nf_nat_ipv4": {
+        "size": "13199",
+        "refcount": "1"
+      },
+      "nf_nat": {
+        "size": "25180",
+        "refcount": "4"
+      },
+      "nf_conntrack": {
+        "size": "99369",
+        "refcount": "8"
+      },
+      "iptable_mangle": {
+        "size": "12695",
+        "refcount": "1"
+      },
+      "iptable_security": {
+        "size": "12705",
+        "refcount": "1"
+      },
+      "iptable_raw": {
+        "size": "12678",
+        "refcount": "1"
+      },
+      "crct10dif_pclmul": {
+        "size": "14307",
+        "refcount": "0"
+      },
+      "crc32_pclmul": {
+        "size": "13133",
+        "refcount": "0"
+      },
+      "crc32c_intel": {
+        "size": "22094",
+        "refcount": "0"
+      },
+      "ghash_clmulni_intel": {
+        "size": "13230",
+        "refcount": "0"
+      },
+      "snd_intel8x0": {
+        "size": "38243",
+        "refcount": "0"
+      },
+      "snd_ac97_codec": {
+        "size": "129476",
+        "refcount": "1"
+      },
+      "ac97_bus": {
+        "size": "12682",
+        "refcount": "1"
       },
       "snd_pcm": {
         "size": "104234",
+        "refcount": "2"
+      },
+      "snd_timer": {
+        "size": "28778",
         "refcount": "1"
+      },
+      "snd": {
+        "size": "80001",
+        "refcount": "4"
       },
       "ppdev": {
         "size": "17635",
@@ -34,45 +174,29 @@
         "size": "28088",
         "refcount": "0"
       },
-      "snd_timer": {
-        "size": "28778",
-        "refcount": "1"
-      },
-      "snd": {
-        "size": "80001",
-        "refcount": "3"
-      },
-      "e1000": {
-        "size": "140895",
+      "serio_raw": {
+        "size": "13434",
         "refcount": "0"
       },
       "soundcore": {
         "size": "14496",
         "refcount": "1"
       },
-      "vboxvideo": {
-        "size": "12669",
-        "refcount": "0"
-      },
       "parport": {
         "size": "40425",
         "refcount": "2"
-      },
-      "serio_raw": {
-        "size": "13434",
-        "refcount": "0"
       },
       "i2c_piix4": {
         "size": "22159",
         "refcount": "0"
       },
-      "vboxguest": {
-        "size": "244174",
-        "refcount": "2"
+      "video": {
+        "size": "19825",
+        "refcount": "0"
       },
-      "drm": {
-        "size": "300858",
-        "refcount": "2"
+      "e1000": {
+        "size": "140895",
+        "refcount": "0"
       },
       "ata_generic": {
         "size": "12923",
@@ -92,16 +216,16 @@
   "platform_version": "21",
   "platform_family": "fedora",
   "filesystem": {
-    "/dev/mapper/vg_vagrant-lv_root": {
-      "kb_size": "39250552",
-      "kb_used": "1051008",
-      "kb_available": "36182676",
-      "percent_used": "3%",
+    "/dev/mapper/fedora--server-root": {
+      "kb_size": "6751000",
+      "kb_used": "1476308",
+      "kb_available": "4908716",
+      "percent_used": "24%",
       "mount": "/",
-      "total_inodes": "2501856",
-      "inodes_used": "36874",
-      "inodes_available": "2464982",
-      "inodes_percent_used": "2%",
+      "total_inodes": "437184",
+      "inodes_used": "62954",
+      "inodes_available": "374230",
+      "inodes_percent_used": "15%",
       "fs_type": "ext4",
       "mount_options": [
         "rw",
@@ -109,37 +233,37 @@
         "seclabel",
         "data=ordered"
       ],
-      "uuid": "156373e5-a9ef-4f75-827f-faa68f0d01e0"
+      "uuid": "3d77e30d-804a-4c26-8e8b-5fa3dae27fe7"
     },
     "devtmpfs": {
-      "kb_size": "243568",
+      "kb_size": "498424",
       "kb_used": "0",
-      "kb_available": "243568",
+      "kb_available": "498424",
       "percent_used": "0%",
       "mount": "/dev",
-      "total_inodes": "60892",
-      "inodes_used": "325",
-      "inodes_available": "60567",
+      "total_inodes": "124606",
+      "inodes_used": "346",
+      "inodes_available": "124260",
       "inodes_percent_used": "1%",
       "fs_type": "devtmpfs",
       "mount_options": [
         "rw",
         "nosuid",
         "seclabel",
-        "size=243568k",
-        "nr_inodes=60892",
+        "size=498424k",
+        "nr_inodes=124606",
         "mode=755"
       ]
     },
     "tmpfs": {
-      "kb_size": "50160",
+      "kb_size": "101764",
       "kb_used": "0",
-      "kb_available": "50160",
+      "kb_available": "101764",
       "percent_used": "0%",
-      "mount": "/run/user/1000",
-      "total_inodes": "62698",
+      "mount": "/run/user/0",
+      "total_inodes": "127200",
       "inodes_used": "4",
-      "inodes_available": "62694",
+      "inodes_available": "127196",
       "inodes_percent_used": "1%",
       "fs_type": "tmpfs",
       "mount_options": [
@@ -148,21 +272,19 @@
         "nodev",
         "relatime",
         "seclabel",
-        "size=50160k",
-        "mode=700",
-        "uid=1000",
-        "gid=1000"
+        "size=101764k",
+        "mode=700"
       ]
     },
     "/dev/sda1": {
       "kb_size": "487652",
-      "kb_used": "69165",
-      "kb_available": "388791",
-      "percent_used": "16%",
+      "kb_used": "91772",
+      "kb_available": "366184",
+      "percent_used": "21%",
       "mount": "/boot",
       "total_inodes": "128016",
-      "inodes_used": "335",
-      "inodes_available": "127681",
+      "inodes_used": "336",
+      "inodes_available": "127680",
       "inodes_percent_used": "1%",
       "fs_type": "ext4",
       "mount_options": [
@@ -171,7 +293,7 @@
         "seclabel",
         "data=ordered"
       ],
-      "uuid": "256eda74-1519-47e9-90e9-ab0d9d319cee"
+      "uuid": "88870e9e-cbc9-44c5-808c-16a44943d7a2"
     },
     "sysfs": {
       "mount": "/sys",
@@ -260,21 +382,18 @@
         "relatime"
       ]
     },
-    "debugfs": {
-      "mount": "/sys/kernel/debug",
-      "fs_type": "debugfs",
-      "mount_options": [
-        "rw",
-        "relatime"
-      ]
-    },
-    "hugetlbfs": {
-      "mount": "/dev/hugepages",
-      "fs_type": "hugetlbfs",
+    "systemd-1": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "autofs",
       "mount_options": [
         "rw",
         "relatime",
-        "seclabel"
+        "fd=28",
+        "pgrp=1",
+        "timeout=300",
+        "minproto=5",
+        "maxproto=5",
+        "direct"
       ]
     },
     "mqueue": {
@@ -286,27 +405,30 @@
         "seclabel"
       ]
     },
-    "systemd-1": {
-      "mount": "/proc/sys/fs/binfmt_misc",
-      "fs_type": "autofs",
+    "hugetlbfs": {
+      "mount": "/dev/hugepages",
+      "fs_type": "hugetlbfs",
       "mount_options": [
         "rw",
         "relatime",
-        "fd=30",
-        "pgrp=1",
-        "timeout=300",
-        "minproto=5",
-        "maxproto=5",
-        "direct"
+        "seclabel"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "relatime"
       ]
     },
     "/dev/sda2": {
       "fs_type": "LVM2_member",
-      "uuid": "mcvcIC-Mpjt-lidp-ADZv-Wit5-1m16-2dX7GB"
+      "uuid": "Vs9OTc-AQ6d-nPjp-MWLy-1jo4-eIAr-nhqnwY"
     },
-    "/dev/mapper/vg_vagrant-lv_swap": {
+    "/dev/mapper/fedora--server-swap": {
       "fs_type": "swap",
-      "uuid": "31221702-d950-4501-93ca-1377cf988999"
+      "uuid": "8df4d3b2-8a03-4a81-8c95-2949196fce59"
     },
     "rootfs": {
       "mount": "/",
@@ -317,28 +439,163 @@
       ]
     }
   },
-  "dmi": {
-  },
+  "ohai_time": 1445967668.6768591,
   "command": {
     "ps": "ps -ef"
   },
-  "ohai_time": 1419395752.2835963,
+  "dmi": {
+    "dmidecode_version": "2.12",
+    "smbios_version": "2.5",
+    "structures": {
+      "count": "10",
+      "size": "449"
+    },
+    "table_location": "0x000E1000",
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "innotek GmbH",
+          "Version": "VirtualBox",
+          "Release Date": "12/01/2006",
+          "Address": "0xE0000",
+          "Runtime Size": "128 kB",
+          "ROM Size": "128 kB",
+          "Characteristics": {
+            "ISA is supported": null,
+            "PCI is supported": null,
+            "Boot from CD is supported": null,
+            "Selectable boot is supported": null,
+            "8042 keyboard services are supported (int 9h)": null,
+            "CGA/mono video services are supported (int 10h)": null,
+            "ACPI is supported": null
+          }
+        }
+      ],
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox",
+      "release_date": "12/01/2006",
+      "address": "0xE0000",
+      "runtime_size": "128 kB",
+      "rom_size": "128 kB"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0001",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "innotek GmbH",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "UUID": "E45F493E-7B6A-48C7-9825-F21302300869",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Virtual Machine"
+        }
+      ],
+      "manufacturer": "innotek GmbH",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "uuid": "E45F493E-7B6A-48C7-9825-F21302300869",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Virtual Machine"
+    },
+    "base_board": {
+      "all_records": [
+        {
+          "record_id": "0x0008",
+          "size": "2",
+          "application_identifier": "Base Board Information",
+          "Manufacturer": "Oracle Corporation",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "Asset Tag": "Not Specified",
+          "Features": {
+            "Board is a hosting board": null
+          },
+          "Location In Chassis": "Not Specified",
+          "Chassis Handle": "0x0003",
+          "Type": "Motherboard",
+          "Contained Object Handles": "0"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "asset_tag": "Not Specified",
+      "location_in_chassis": "Not Specified",
+      "chassis_handle": "0x0003",
+      "type": "Motherboard",
+      "contained_object_handles": "0"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0003",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Oracle Corporation",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "None"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "Not Specified",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "None"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "0x0002",
+          "size": "11",
+          "application_identifier": "OEM Strings",
+          "String 1": "vboxVer_5.0.6",
+          "String 2": "vboxRev_103037"
+        }
+      ],
+      "string_1": "vboxVer_5.0.6",
+      "string_2": "vboxRev_103037"
+    }
+  },
   "languages": {
     "ruby": {
       "bin_dir": "/usr/local/bin",
       "gem_bin": "/usr/local/bin/gem",
       "gems_dir": "/usr/local/gems",
       "ruby_bin": "/usr/local/bin/ruby"
-    }
+    },
+    "powershell": null
   },
   "chef_packages": {
     "chef": {
-      "version": "12.0.3",
-      "chef_root": "/usr/local/gems/chef-12.0.3/lib"
+      "version": "12.5.1",
+      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
     },
     "ohai": {
-      "version": "8.0.1",
-      "ohai_root": "/usr/local/gems/ohai-8.0.1/lib/ohai"
+      "version": "8.7.0",
+      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/fedora/22.json
+++ b/lib/fauxhai/platforms/fedora/22.json
@@ -1,111 +1,34 @@
 {
-  "kernel": {
-    "name": "Linux",
-    "release": "4.0.4-301.fc22.x86_64",
-    "version": "#1 SMP Thu May 21 13:10:33 UTC 2015",
-    "machine": "x86_64",
-    "os": "GNU/Linux",
-    "modules": {
-      "ppdev": {
-        "size": "20480",
-        "refcount": "0"
-      },
-      "serio_raw": {
-        "size": "16384",
-        "refcount": "0"
-      },
-      "i2c_piix4": {
-        "size": "24576",
-        "refcount": "0"
-      },
-      "e1000": {
-        "size": "139264",
-        "refcount": "0"
-      },
-      "iosf_mbi": {
-        "size": "16384",
-        "refcount": "0"
-      },
-      "parport_pc": {
-        "size": "28672",
-        "refcount": "0"
-      },
-      "parport": {
-        "size": "40960",
-        "refcount": "2"
-      },
-      "video": {
-        "size": "24576",
-        "refcount": "0"
-      },
-      "acpi_cpufreq": {
-        "size": "20480",
-        "refcount": "0"
-      },
-      "nfsd": {
-        "size": "331776",
-        "refcount": "1"
-      },
-      "auth_rpcgss": {
-        "size": "65536",
-        "refcount": "1"
-      },
-      "nfs_acl": {
-        "size": "16384",
-        "refcount": "1"
-      },
-      "lockd": {
-        "size": "94208",
-        "refcount": "1"
-      },
-      "grace": {
-        "size": "16384",
-        "refcount": "2"
-      },
-      "sunrpc": {
-        "size": "311296",
-        "refcount": "7"
-      },
-      "ata_generic": {
-        "size": "16384",
-        "refcount": "0"
-      },
-      "pata_acpi": {
-        "size": "16384",
-        "refcount": "0"
-      }
-    }
-  },
   "filesystem": {
     "devtmpfs": {
-      "kb_size": "242940",
+      "kb_size": "498072",
       "kb_used": "0",
-      "kb_available": "242940",
+      "kb_available": "498072",
       "percent_used": "0%",
       "mount": "/dev",
-      "total_inodes": "60735",
-      "inodes_used": "309",
-      "inodes_available": "60426",
+      "total_inodes": "124518",
+      "inodes_used": "348",
+      "inodes_available": "124170",
       "inodes_percent_used": "1%",
       "fs_type": "devtmpfs",
       "mount_options": [
         "rw",
         "nosuid",
         "seclabel",
-        "size=242940k",
-        "nr_inodes=60735",
+        "size=498072k",
+        "nr_inodes=124518",
         "mode=755"
       ]
     },
     "tmpfs": {
-      "kb_size": "50132",
+      "kb_size": "101736",
       "kb_used": "0",
-      "kb_available": "50132",
+      "kb_available": "101736",
       "percent_used": "0%",
-      "mount": "/run/user/1000",
-      "total_inodes": "62664",
+      "mount": "/run/user/0",
+      "total_inodes": "127166",
       "inodes_used": "4",
-      "inodes_available": "62660",
+      "inodes_available": "127162",
       "inodes_percent_used": "1%",
       "fs_type": "tmpfs",
       "mount_options": [
@@ -114,36 +37,36 @@
         "nodev",
         "relatime",
         "seclabel",
-        "size=50132k",
-        "mode=700",
-        "uid=1000",
-        "gid=1000"
+        "size=101736k",
+        "mode=700"
       ]
     },
-    "/dev/mapper/vg_vagrant-lv_root": {
-      "kb_size": "39572896",
-      "kb_used": "1058576",
-      "kb_available": "36481068",
-      "percent_used": "3%",
+    "/dev/mapper/fedora-root": {
+      "kb_size": "7022592",
+      "kb_used": "1517044",
+      "kb_available": "5505548",
+      "percent_used": "22%",
       "mount": "/",
-      "total_inodes": "2523136",
-      "inodes_used": "38673",
-      "inodes_available": "2484463",
-      "inodes_percent_used": "2%",
-      "fs_type": "ext4",
+      "total_inodes": "7032832",
+      "inodes_used": "66461",
+      "inodes_available": "6966371",
+      "inodes_percent_used": "1%",
+      "fs_type": "xfs",
       "mount_options": [
         "rw",
         "relatime",
         "seclabel",
-        "data=ordered"
+        "attr2",
+        "inode64",
+        "noquota"
       ],
-      "uuid": "6693f9d4-89b4-458a-affe-0fb8d0b5cef9"
+      "uuid": "049a5686-8acb-4c2d-b572-e532000e0271"
     },
     "/dev/sda1": {
       "kb_size": "487652",
-      "kb_used": "75775",
-      "kb_available": "382181",
-      "percent_used": "17%",
+      "kb_used": "94285",
+      "kb_available": "363671",
+      "percent_used": "21%",
       "mount": "/boot",
       "total_inodes": "128016",
       "inodes_used": "336",
@@ -156,7 +79,7 @@
         "seclabel",
         "data=ordered"
       ],
-      "uuid": "b25fca88-1872-4d94-909d-83cddcc83186"
+      "uuid": "5d221dec-2612-4617-a230-3e6180407a8d"
     },
     "sysfs": {
       "mount": "/sys",
@@ -207,7 +130,7 @@
       ]
     },
     "cgroup": {
-      "mount": "/sys/fs/cgroup/memory",
+      "mount": "/sys/fs/cgroup/freezer",
       "fs_type": "cgroup",
       "mount_options": [
         "rw",
@@ -215,7 +138,7 @@
         "nodev",
         "noexec",
         "relatime",
-        "memory"
+        "freezer"
       ]
     },
     "pstore": {
@@ -252,7 +175,7 @@
       "mount_options": [
         "rw",
         "relatime",
-        "fd=29",
+        "fd=34",
         "pgrp=1",
         "timeout=300",
         "minproto=5",
@@ -305,17 +228,258 @@
     },
     "/dev/sda2": {
       "fs_type": "LVM2_member",
-      "uuid": "dfEcIR-0Kaf-2HC1-cDjE-7UQb-gPAK-AeNjdV"
+      "uuid": "E7N1N2-q4Au-kCDe-1s2j-U06h-B7BY-WDYvnq"
     },
-    "/dev/mapper/vg_vagrant-lv_swap": {
+    "/dev/mapper/fedora-swap": {
       "fs_type": "swap",
-      "uuid": "b87fa559-4f5d-4549-985a-0580eb4a0a35"
+      "uuid": "0c37a0fb-8a32-4ffd-be59-9062994e2e96"
     }
+  },
+  "kernel": {
+    "name": "Linux",
+    "release": "4.0.4-301.fc22.x86_64",
+    "version": "#1 SMP Thu May 21 13:10:33 UTC 2015",
+    "machine": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "ip6t_rpfilter": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ip6t_REJECT": {
+        "size": "16384",
+        "refcount": "2"
+      },
+      "nf_reject_ipv6": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "xt_conntrack": {
+        "size": "16384",
+        "refcount": "13"
+      },
+      "ebtable_nat": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "ebtable_broute": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "bridge": {
+        "size": "114688",
+        "refcount": "1"
+      },
+      "stp": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "llc": {
+        "size": "16384",
+        "refcount": "2"
+      },
+      "ebtable_filter": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "ebtables": {
+        "size": "32768",
+        "refcount": "3"
+      },
+      "ip6table_nat": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "nf_conntrack_ipv6": {
+        "size": "20480",
+        "refcount": "8"
+      },
+      "nf_defrag_ipv6": {
+        "size": "36864",
+        "refcount": "1"
+      },
+      "nf_nat_ipv6": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ip6table_mangle": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ip6table_security": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ip6table_raw": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ip6table_filter": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ip6_tables": {
+        "size": "28672",
+        "refcount": "5"
+      },
+      "iptable_nat": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "nf_conntrack_ipv4": {
+        "size": "16384",
+        "refcount": "7"
+      },
+      "nf_defrag_ipv4": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "nf_nat_ipv4": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "nf_nat": {
+        "size": "28672",
+        "refcount": "2"
+      },
+      "nf_conntrack": {
+        "size": "106496",
+        "refcount": "6"
+      },
+      "iptable_mangle": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "iptable_security": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "iptable_raw": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "crct10dif_pclmul": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "crc32_pclmul": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "ghash_clmulni_intel": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "ppdev": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "snd_intel8x0": {
+        "size": "40960",
+        "refcount": "0"
+      },
+      "snd_ac97_codec": {
+        "size": "135168",
+        "refcount": "1"
+      },
+      "ac97_bus": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_pcm": {
+        "size": "114688",
+        "refcount": "2"
+      },
+      "snd_timer": {
+        "size": "32768",
+        "refcount": "1"
+      },
+      "i2c_piix4": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "snd": {
+        "size": "77824",
+        "refcount": "4"
+      },
+      "parport_pc": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "parport": {
+        "size": "40960",
+        "refcount": "2"
+      },
+      "soundcore": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "video": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "acpi_cpufreq": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "nfsd": {
+        "size": "331776",
+        "refcount": "1"
+      },
+      "auth_rpcgss": {
+        "size": "65536",
+        "refcount": "1"
+      },
+      "nfs_acl": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "lockd": {
+        "size": "94208",
+        "refcount": "1"
+      },
+      "grace": {
+        "size": "16384",
+        "refcount": "2"
+      },
+      "sunrpc": {
+        "size": "311296",
+        "refcount": "7"
+      },
+      "xfs": {
+        "size": "925696",
+        "refcount": "1"
+      },
+      "libcrc32c": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "crc32c_intel": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "e1000": {
+        "size": "139264",
+        "refcount": "0"
+      },
+      "ata_generic": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "pata_acpi": {
+        "size": "16384",
+        "refcount": "0"
+      }
+    }
+  },
+  "lsb": {
   },
   "os": "linux",
   "os_version": "4.0.4-301.fc22.x86_64",
-  "lsb": {
-  },
   "platform": "fedora",
   "platform_version": "22",
   "platform_family": "fedora",
@@ -323,8 +487,142 @@
     "ps": "ps -ef"
   },
   "dmi": {
+    "dmidecode_version": "2.12",
+    "smbios_version": "2.5",
+    "structures": {
+      "count": "10",
+      "size": "449"
+    },
+    "table_location": "0x000E1000",
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "innotek GmbH",
+          "Version": "VirtualBox",
+          "Release Date": "12/01/2006",
+          "Address": "0xE0000",
+          "Runtime Size": "128 kB",
+          "ROM Size": "128 kB",
+          "Characteristics": {
+            "ISA is supported": null,
+            "PCI is supported": null,
+            "Boot from CD is supported": null,
+            "Selectable boot is supported": null,
+            "8042 keyboard services are supported (int 9h)": null,
+            "CGA/mono video services are supported (int 10h)": null,
+            "ACPI is supported": null
+          }
+        }
+      ],
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox",
+      "release_date": "12/01/2006",
+      "address": "0xE0000",
+      "runtime_size": "128 kB",
+      "rom_size": "128 kB"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0001",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "innotek GmbH",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "UUID": "D5F3278A-A815-4EE8-B2EF-20D45531B7EF",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Virtual Machine"
+        }
+      ],
+      "manufacturer": "innotek GmbH",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "uuid": "D5F3278A-A815-4EE8-B2EF-20D45531B7EF",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Virtual Machine"
+    },
+    "base_board": {
+      "all_records": [
+        {
+          "record_id": "0x0008",
+          "size": "2",
+          "application_identifier": "Base Board Information",
+          "Manufacturer": "Oracle Corporation",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "Asset Tag": "Not Specified",
+          "Features": {
+            "Board is a hosting board": null
+          },
+          "Location In Chassis": "Not Specified",
+          "Chassis Handle": "0x0003",
+          "Type": "Motherboard",
+          "Contained Object Handles": "0"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "asset_tag": "Not Specified",
+      "location_in_chassis": "Not Specified",
+      "chassis_handle": "0x0003",
+      "type": "Motherboard",
+      "contained_object_handles": "0"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0003",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Oracle Corporation",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "None"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "Not Specified",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "None"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "0x0002",
+          "size": "11",
+          "application_identifier": "OEM Strings",
+          "String 1": "vboxVer_5.0.6",
+          "String 2": "vboxRev_103037"
+        }
+      ],
+      "string_1": "vboxVer_5.0.6",
+      "string_2": "vboxRev_103037"
+    }
   },
-  "ohai_time": 1434146213.682304,
+  "ohai_time": 1445967719.7771075,
   "languages": {
     "ruby": {
       "bin_dir": "/usr/local/bin",
@@ -336,12 +634,12 @@
   },
   "chef_packages": {
     "chef": {
-      "version": "12.3.0",
-      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+      "version": "12.5.1",
+      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
     },
     "ohai": {
-      "version": "8.3.0",
-      "ohai_root": "/usr/local/gems/ohai-8.3.0/lib/ohai"
+      "version": "8.7.0",
+      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/ubuntu/12.04.json
+++ b/lib/fauxhai/platforms/ubuntu/12.04.json
@@ -1,77 +1,82 @@
 {
   "kernel": {
     "name": "Linux",
-    "release": "3.2.0-26-generic",
-    "version": "#41-Ubuntu SMP Thu Jun 14 17:49:24 UTC 2012",
+    "release": "3.2.0-92-generic",
+    "version": "#131-Ubuntu SMP Tue Oct 20 16:16:02 UTC 2015",
     "machine": "x86_64",
+    "os": "GNU/Linux",
     "modules": {
-      "vboxsf": {
-        "size": "39436",
-        "refcount": "1"
-      },
       "vesafb": {
         "size": "13844",
         "refcount": "1"
       },
-      "ppdev": {
-        "size": "17113",
+      "joydev": {
+        "size": "17693",
         "refcount": "0"
       },
-      "nfsd": {
-        "size": "277809",
-        "refcount": "2"
-      },
-      "nfs": {
-        "size": "356315",
+      "usbhid": {
+        "size": "47238",
         "refcount": "0"
-      },
-      "lockd": {
-        "size": "86161",
-        "refcount": "2"
-      },
-      "fscache": {
-        "size": "61529",
-        "refcount": "1"
-      },
-      "auth_rpcgss": {
-        "size": "53380",
-        "refcount": "2"
-      },
-      "nfs_acl": {
-        "size": "12883",
-        "refcount": "2"
-      },
-      "sunrpc": {
-        "size": "245464",
-        "refcount": "6"
       },
       "psmouse": {
-        "size": "87692",
+        "size": "98243",
         "refcount": "0"
       },
-      "vboxguest": {
-        "size": "228953",
-        "refcount": "2"
+      "hid": {
+        "size": "99883",
+        "refcount": "1"
       },
-      "i2c_piix4": {
-        "size": "13301",
+      "video": {
+        "size": "19651",
         "refcount": "0"
       },
       "serio_raw": {
         "size": "13211",
         "refcount": "0"
       },
-      "ext2": {
-        "size": "73795",
+      "snd_intel8x0": {
+        "size": "38570",
+        "refcount": "0"
+      },
+      "snd_ac97_codec": {
+        "size": "134869",
         "refcount": "1"
       },
-      "parport_pc": {
-        "size": "32866",
+      "ac97_bus": {
+        "size": "12730",
+        "refcount": "1"
+      },
+      "snd_pcm": {
+        "size": "97275",
+        "refcount": "2"
+      },
+      "snd_timer": {
+        "size": "29990",
+        "refcount": "1"
+      },
+      "snd": {
+        "size": "79081",
+        "refcount": "4"
+      },
+      "soundcore": {
+        "size": "15091",
+        "refcount": "1"
+      },
+      "i2c_piix4": {
+        "size": "13301",
         "refcount": "0"
+      },
+      "snd_page_alloc": {
+        "size": "18529",
+        "refcount": "2"
       },
       "mac_hid": {
         "size": "13253",
         "refcount": "0"
+      },
+      "ext2": {
+        "size": "73824",
+        "refcount": "1"
       },
       "lp": {
         "size": "17799",
@@ -79,23 +84,165 @@
       },
       "parport": {
         "size": "46562",
-        "refcount": "3"
+        "refcount": "1"
       },
       "e1000": {
-        "size": "108471",
+        "size": "108642",
         "refcount": "0"
       }
-    },
-    "os": "GNU/Linux"
+    }
   },
   "os": "linux",
-  "os_version": "3.2.0-26-generic",
+  "os_version": "3.2.0-92-generic",
+  "lsb": {
+    "id": "Ubuntu",
+    "release": "12.04",
+    "codename": "precise",
+    "description": "Ubuntu 12.04.5 LTS"
+  },
+  "platform": "ubuntu",
+  "platform_version": "12.04",
+  "platform_family": "debian",
+  "ohai_time": 1445838957.0466776,
+  "filesystem": {
+    "/dev/mapper/1204--vg-root": {
+      "kb_size": "11078912",
+      "kb_used": "2393092",
+      "kb_available": "8123032",
+      "percent_used": "23%",
+      "mount": "/",
+      "total_inodes": "704512",
+      "inodes_used": "140377",
+      "inodes_available": "564135",
+      "inodes_percent_used": "20%",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "errors=remount-ro"
+      ],
+      "uuid": "0d89cb0e-612c-4e16-a878-3af9793718a5"
+    },
+    "udev": {
+      "kb_size": "500644",
+      "kb_used": "4",
+      "kb_available": "500640",
+      "percent_used": "1%",
+      "mount": "/dev",
+      "total_inodes": "125161",
+      "inodes_used": "468",
+      "inodes_available": "124693",
+      "inodes_percent_used": "1%",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "mode=0755"
+      ]
+    },
+    "tmpfs": {
+      "kb_size": "101944",
+      "kb_used": "300",
+      "kb_available": "101644",
+      "percent_used": "1%",
+      "mount": "/run",
+      "total_inodes": "127426",
+      "inodes_used": "361",
+      "inodes_available": "127065",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "noexec",
+        "nosuid",
+        "size=10%",
+        "mode=0755"
+      ]
+    },
+    "none": {
+      "kb_size": "509704",
+      "kb_used": "0",
+      "kb_available": "509704",
+      "percent_used": "0%",
+      "mount": "/run/shm",
+      "total_inodes": "127426",
+      "inodes_used": "1",
+      "inodes_available": "127425",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev"
+      ]
+    },
+    "/dev/sda1": {
+      "kb_size": "240972",
+      "kb_used": "129548",
+      "kb_available": "98983",
+      "percent_used": "57%",
+      "mount": "/boot",
+      "total_inodes": "62248",
+      "inodes_used": "250",
+      "inodes_available": "61998",
+      "inodes_percent_used": "1%",
+      "fs_type": "ext2",
+      "mount_options": [
+        "rw"
+      ],
+      "uuid": "e4e4a20d-8f97-4df2-a1d8-4bc501108249"
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "noexec",
+        "nosuid",
+        "nodev"
+      ]
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "noexec",
+        "nosuid",
+        "nodev"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "noexec",
+        "nosuid",
+        "gid=5",
+        "mode=0620"
+      ]
+    },
+    "/dev/sda5": {
+      "fs_type": "LVM2_member",
+      "uuid": "lgFpXF-zjyu-vTGE-MT08-Wkmz-RIxw-uHJy1x"
+    },
+    "/dev/mapper/1204--vg-swap_1": {
+      "fs_type": "swap",
+      "uuid": "6d9f8467-f9f0-4509-b66a-cca47f6656b4"
+    },
+    "rootfs": {
+      "mount": "/",
+      "fs_type": "rootfs",
+      "mount_options": [
+        "rw"
+      ]
+    }
+  },
   "dmi": {
     "dmidecode_version": "2.11",
     "smbios_version": "2.5",
     "structures": {
-      "count": "5",
-      "size": "352"
+      "count": "10",
+      "size": "449"
     },
     "table_location": "0x000E1000",
     "bios": {
@@ -133,12 +280,12 @@
         {
           "record_id": "0x0001",
           "size": "1",
-          "application_identifier": "End Of Table",
+          "application_identifier": "System Information",
           "Manufacturer": "innotek GmbH",
           "Product Name": "VirtualBox",
           "Version": "1.2",
           "Serial Number": "0",
-          "UUID": "5016CB98-F317-45A2-BD11-17E25A2EA3A6",
+          "UUID": "98B0D90E-BF63-4B3B-9CCD-BD6D78A270F5",
           "Wake-up Type": "Power Switch",
           "SKU Number": "Not Specified",
           "Family": "Virtual Machine"
@@ -148,192 +295,104 @@
       "product_name": "VirtualBox",
       "version": "1.2",
       "serial_number": "0",
-      "uuid": "5016CB98-F317-45A2-BD11-17E25A2EA3A6",
+      "uuid": "98B0D90E-BF63-4B3B-9CCD-BD6D78A270F5",
       "wake_up_type": "Power Switch",
       "sku_number": "Not Specified",
       "family": "Virtual Machine"
+    },
+    "base_board": {
+      "all_records": [
+        {
+          "record_id": "0x0008",
+          "size": "2",
+          "application_identifier": "Base Board Information",
+          "Manufacturer": "Oracle Corporation",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "Asset Tag": "Not Specified",
+          "Features": {
+            "Board is a hosting board": null
+          },
+          "Location In Chassis": "Not Specified",
+          "Chassis Handle": "0x0003",
+          "Type": "Motherboard",
+          "Contained Object Handles": "0"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "asset_tag": "Not Specified",
+      "location_in_chassis": "Not Specified",
+      "chassis_handle": "0x0003",
+      "type": "Motherboard",
+      "contained_object_handles": "0"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0003",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Oracle Corporation",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "None"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "Not Specified",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "None"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "0x0002",
+          "size": "11",
+          "application_identifier": "OEM Strings",
+          "String 1": "vboxVer_5.0.6",
+          "String 2": "vboxRev_103037"
+        }
+      ],
+      "string_1": "vboxVer_5.0.6",
+      "string_2": "vboxRev_103037"
     }
   },
   "command": {
     "ps": "ps -ef"
   },
-  "platform": "ubuntu",
-  "platform_version": "12.04",
-  "platform_family": "debian",
-  "lsb": {
-    "codename": "precise",
-    "description": "Ubuntu 12.04 LTS",
-    "release": "12.04",
-    "id": "Ubuntu"
-  },
-  "cpu": {
-    "real": 1,
-    "total": 1
-  },
-  "memory": {
-    "total": "524288kB"
-  },
-  "ohai_time": 1344011611.7613227,
-  "filesystem": {
-    "/dev/mapper/precise64-root": {
-      "kb_size": "82706056",
-      "kb_used": "2267536",
-      "kb_available": "76296236",
-      "percent_used": "3%",
-      "mount": "/",
-      "fs_type": "ext4",
-      "mount_options": [
-        "rw",
-        "errors=remount-ro"
-      ],
-      "uuid": "04834516-b2ee-4f08-a552-63b7367c72ac"
-    },
-    "udev": {
-      "kb_size": "178064",
-      "kb_used": "12",
-      "kb_available": "178052",
-      "percent_used": "1%",
-      "mount": "/dev",
-      "fs_type": "devtmpfs",
-      "mount_options": [
-        "rw",
-        "mode=0755"
-      ]
-    },
-    "tmpfs": {
-      "kb_size": "74856",
-      "kb_used": "268",
-      "kb_available": "74588",
-      "percent_used": "1%",
-      "mount": "/run",
-      "fs_type": "tmpfs",
-      "mount_options": [
-        "rw",
-        "noexec",
-        "nosuid",
-        "size=10%",
-        "mode=0755"
-      ]
-    },
-    "none": {
-      "kb_size": "187132",
-      "kb_used": "0",
-      "kb_available": "187132",
-      "percent_used": "0%",
-      "mount": "/run/shm",
-      "fs_type": "tmpfs",
-      "mount_options": [
-        "rw",
-        "nosuid",
-        "nodev"
-      ]
-    },
-    "/dev/sda1": {
-      "kb_size": "233191",
-      "kb_used": "24973",
-      "kb_available": "195777",
-      "percent_used": "12%",
-      "mount": "/boot",
-      "fs_type": "ext2",
-      "mount_options": [
-        "rw"
-      ],
-      "uuid": "ff82934e-7770-4d45-bc82-ac1751a1e762"
-    },
-    "v-root": {
-      "kb_size": "86890824",
-      "kb_used": "83485620",
-      "kb_available": "3405204",
-      "percent_used": "97%",
-      "mount": "/vagrant",
-      "fs_type": "vboxsf",
-      "mount_options": [
-        "uid=1000",
-        "gid=1000",
-        "rw"
-      ]
-    },
-    "proc": {
-      "mount": "/proc",
-      "fs_type": "proc",
-      "mount_options": [
-        "rw",
-        "noexec",
-        "nosuid",
-        "nodev"
-      ]
-    },
-    "sysfs": {
-      "mount": "/sys",
-      "fs_type": "sysfs",
-      "mount_options": [
-        "rw",
-        "noexec",
-        "nosuid",
-        "nodev"
-      ]
-    },
-    "devpts": {
-      "mount": "/dev/pts",
-      "fs_type": "devpts",
-      "mount_options": [
-        "rw",
-        "noexec",
-        "nosuid",
-        "gid=5",
-        "mode=0620"
-      ]
-    },
-    "rpc_pipefs": {
-      "mount": "/run/rpc_pipefs",
-      "fs_type": "rpc_pipefs",
-      "mount_options": [
-        "rw"
-      ]
-    },
-    "/dev/sda5": {
-      "fs_type": "LVM2_member",
-      "uuid": "TJpj2t-VYzl-7RoY-7X64-DIx8-hAaV-g23g6v"
-    },
-    "/dev/mapper/precise64-swap_1": {
-      "fs_type": "swap",
-      "uuid": "558a90aa-6b59-43dc-8919-5ce2927e561b"
-    },
-    "rootfs": {
-      "mount": "/",
-      "fs_type": "rootfs",
-      "mount_options": [
-        "rw"
-      ]
-    }
-  },
   "languages": {
     "ruby": {
-      "platform": "x86_64-linux",
-      "version": "1.9.3",
-      "release_date": "2012-04-20",
-      "target": "x86_64-unknown-linux-gnu",
-      "target_cpu": "x86_64",
-      "target_vendor": "unknown",
-      "target_os": "linux",
-      "host": "x86_64-unknown-linux-gnu",
-      "host_cpu": "x86_64",
-      "host_os": "linux-gnu",
-      "host_vendor": "unknown",
       "bin_dir": "/usr/local/bin",
-      "ruby_bin": "/usr/local/bin/ruby",
+      "gem_bin": "/usr/local/bin/gem",
       "gems_dir": "/usr/local/gems",
-      "gem_bin": "/usr/local/bin/gem"
-    }
+      "ruby_bin": "/usr/local/bin/ruby"
+    },
+    "powershell": null
   },
   "chef_packages": {
     "chef": {
-      "version": "10.12.0",
-      "chef_root": "/usr/local/gems/chef-10.12.0/lib"
+      "version": "12.5.1",
+      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
     },
     "ohai": {
-      "version": "6.14.0",
-      "ohai_root": "/usr/local/gems/ohai-6.14.0/lib/ohai"
+      "version": "8.7.0",
+      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {
@@ -398,7 +457,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -434,5 +494,12 @@
     }
   },
   "uptime": "30 days 15 hours 07 minutes 30 seconds",
-  "uptime_seconds": 2646450
+  "uptime_seconds": 2646450,
+  "cpu": {
+    "real": 1,
+    "total": 1
+  },
+  "memory": {
+    "total": "1024MB"
+  }
 }

--- a/lib/fauxhai/platforms/ubuntu/14.04.json
+++ b/lib/fauxhai/platforms/ubuntu/14.04.json
@@ -1,146 +1,256 @@
 {
   "kernel": {
     "name": "Linux",
-    "release": "3.13.0-24-generic",
-    "version": "#46-Ubuntu SMP Thu Apr 10 19:11:08 UTC 2014",
+    "release": "3.13.0-66-generic",
+    "version": "#108-Ubuntu SMP Wed Oct 7 15:20:27 UTC 2015",
     "machine": "x86_64",
+    "os": "GNU/Linux",
     "modules": {
-      "ppdev": {
-        "size": "17671",
+      "joydev": {
+        "size": "17381",
         "refcount": "0"
       },
-      "vmwgfx": {
-        "size": "175358",
+      "hid_generic": {
+        "size": "12548",
         "refcount": "0"
       },
-      "kvm_intel": {
-        "size": "143060",
+      "crct10dif_pclmul": {
+        "size": "14289",
         "refcount": "0"
       },
-      "kvm": {
-        "size": "451511",
+      "crc32_pclmul": {
+        "size": "13113",
+        "refcount": "0"
+      },
+      "ghash_clmulni_intel": {
+        "size": "13216",
+        "refcount": "0"
+      },
+      "aesni_intel": {
+        "size": "55624",
+        "refcount": "0"
+      },
+      "aes_x86_64": {
+        "size": "17131",
         "refcount": "1"
       },
-      "ttm": {
-        "size": "85115",
+      "lrw": {
+        "size": "13286",
         "refcount": "1"
       },
-      "drm": {
-        "size": "302817",
+      "gf128mul": {
+        "size": "14951",
+        "refcount": "1"
+      },
+      "glue_helper": {
+        "size": "13990",
+        "refcount": "1"
+      },
+      "ablk_helper": {
+        "size": "13597",
+        "refcount": "1"
+      },
+      "cryptd": {
+        "size": "20359",
+        "refcount": "3"
+      },
+      "snd_intel8x0": {
+        "size": "38153",
+        "refcount": "0"
+      },
+      "snd_ac97_codec": {
+        "size": "130285",
+        "refcount": "1"
+      },
+      "ac97_bus": {
+        "size": "12730",
+        "refcount": "1"
+      },
+      "snd_pcm": {
+        "size": "102099",
         "refcount": "2"
-      },
-      "psmouse": {
-        "size": "102222",
-        "refcount": "0"
       },
       "serio_raw": {
         "size": "13462",
+        "refcount": "0"
+      },
+      "usbhid": {
+        "size": "52659",
         "refcount": "0"
       },
       "i2c_piix4": {
         "size": "22155",
         "refcount": "0"
       },
-      "parport_pc": {
-        "size": "32701",
+      "hid": {
+        "size": "106148",
+        "refcount": "2"
+      },
+      "snd_page_alloc": {
+        "size": "18710",
+        "refcount": "2"
+      },
+      "snd_timer": {
+        "size": "29482",
         "refcount": "1"
+      },
+      "snd": {
+        "size": "69322",
+        "refcount": "4"
+      },
+      "soundcore": {
+        "size": "12680",
+        "refcount": "1"
+      },
+      "video": {
+        "size": "19476",
+        "refcount": "0"
       },
       "lp": {
         "size": "17759",
         "refcount": "0"
       },
-      "parport": {
-        "size": "42348",
-        "refcount": "3"
-      },
       "mac_hid": {
         "size": "13205",
         "refcount": "0"
       },
-      "floppy": {
-        "size": "69370",
+      "parport": {
+        "size": "42348",
+        "refcount": "1"
+      },
+      "psmouse": {
+        "size": "106692",
+        "refcount": "0"
+      },
+      "ahci": {
+        "size": "34091",
+        "refcount": "2"
+      },
+      "libahci": {
+        "size": "32716",
+        "refcount": "1"
+      },
+      "e1000": {
+        "size": "145227",
+        "refcount": "0"
+      },
+      "pata_acpi": {
+        "size": "13038",
         "refcount": "0"
       }
-    },
-    "os": "GNU/Linux"
+    }
   },
   "os": "linux",
-  "os_version": "3.13.0-24-generic",
+  "os_version": "3.13.0-66-generic",
   "lsb": {
     "id": "Ubuntu",
     "release": "14.04",
     "codename": "trusty",
-    "description": "Ubuntu 14.04 LTS"
+    "description": "Ubuntu 14.04.3 LTS"
   },
   "platform": "ubuntu",
   "platform_version": "14.04",
   "platform_family": "debian",
   "dmi": {
     "dmidecode_version": "2.12",
-    "smbios_version": "2.4",
+    "smbios_version": "2.5",
     "structures": {
       "count": "10",
-      "size": "263"
+      "size": "449"
     },
+    "table_location": "0x000E1000",
     "bios": {
       "all_records": [
         {
           "record_id": "0x0000",
           "size": "0",
           "application_identifier": "BIOS Information",
-          "Vendor": "Bochs",
-          "Version": "Bochs",
-          "Release Date": "01/01/2007",
-          "Address": "0xE8000",
-          "Runtime Size": "96 kB",
-          "ROM Size": "64 kB",
+          "Vendor": "innotek GmbH",
+          "Version": "VirtualBox",
+          "Release Date": "12/01/2006",
+          "Address": "0xE0000",
+          "Runtime Size": "128 kB",
+          "ROM Size": "128 kB",
           "Characteristics": {
-            "BIOS characteristics not supported": null,
-            "Targeted content distribution is supported": null
-          },
-          "BIOS Revision": "1.0"
+            "ISA is supported": null,
+            "PCI is supported": null,
+            "Boot from CD is supported": null,
+            "Selectable boot is supported": null,
+            "8042 keyboard services are supported (int 9h)": null,
+            "CGA/mono video services are supported (int 10h)": null,
+            "ACPI is supported": null
+          }
         }
       ],
-      "vendor": "Bochs",
-      "version": "Bochs",
-      "release_date": "01/01/2007",
-      "address": "0xE8000",
-      "runtime_size": "96 kB",
-      "rom_size": "64 kB",
-      "bios_revision": "1.0"
+      "vendor": "innotek GmbH",
+      "version": "VirtualBox",
+      "release_date": "12/01/2006",
+      "address": "0xE0000",
+      "runtime_size": "128 kB",
+      "rom_size": "128 kB"
     },
     "system": {
       "all_records": [
         {
-          "record_id": "0x0100",
+          "record_id": "0x0001",
           "size": "1",
           "application_identifier": "System Information",
-          "Manufacturer": "Bochs",
-          "Product Name": "Bochs",
-          "Version": "Not Specified",
-          "Serial Number": "Not Specified",
-          "UUID": "4AC619F2-C97D-11E3-A9D0-04010897BD01",
+          "Manufacturer": "innotek GmbH",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "UUID": "7A08316A-790F-49C0-A7BC-B7108E3EA8A7",
           "Wake-up Type": "Power Switch",
           "SKU Number": "Not Specified",
-          "Family": "Not Specified"
+          "Family": "Virtual Machine"
         }
       ],
-      "manufacturer": "Bochs",
-      "product_name": "Bochs",
-      "version": "Not Specified",
-      "serial_number": "Not Specified",
-      "uuid": "4AC619F2-C97D-11E3-A9D0-04010897BD01",
+      "manufacturer": "innotek GmbH",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "uuid": "7A08316A-790F-49C0-A7BC-B7108E3EA8A7",
       "wake_up_type": "Power Switch",
       "sku_number": "Not Specified",
-      "family": "Not Specified"
+      "family": "Virtual Machine"
+    },
+    "base_board": {
+      "all_records": [
+        {
+          "record_id": "0x0008",
+          "size": "2",
+          "application_identifier": "Base Board Information",
+          "Manufacturer": "Oracle Corporation",
+          "Product Name": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "Asset Tag": "Not Specified",
+          "Features": {
+            "Board is a hosting board": null
+          },
+          "Location In Chassis": "Not Specified",
+          "Chassis Handle": "0x0003",
+          "Type": "Motherboard",
+          "Contained Object Handles": "0"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "product_name": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "asset_tag": "Not Specified",
+      "location_in_chassis": "Not Specified",
+      "chassis_handle": "0x0003",
+      "type": "Motherboard",
+      "contained_object_handles": "0"
     },
     "chassis": {
       "all_records": [
         {
-          "record_id": "0x0300",
+          "record_id": "0x0003",
           "size": "3",
           "application_identifier": "Chassis Information",
-          "Manufacturer": "Bochs",
+          "Manufacturer": "Oracle Corporation",
           "Type": "Other",
           "Lock": "Not Present",
           "Version": "Not Specified",
@@ -149,13 +259,10 @@
           "Boot-up State": "Safe",
           "Power Supply State": "Safe",
           "Thermal State": "Safe",
-          "Security Status": "Unknown",
-          "OEM Information": "0x00000000",
-          "Height": "Unspecified",
-          "Number Of Power Cords": "Unspecified"
+          "Security Status": "None"
         }
       ],
-      "manufacturer": "Bochs",
+      "manufacturer": "Oracle Corporation",
       "type": "Other",
       "lock": "Not Present",
       "version": "Not Specified",
@@ -164,115 +271,39 @@
       "boot_up_state": "Safe",
       "power_supply_state": "Safe",
       "thermal_state": "Safe",
-      "security_status": "Unknown",
-      "oem_information": "0x00000000",
-      "height": "Unspecified",
-      "number_of_power_cords": "Unspecified"
+      "security_status": "None"
     },
-    "processor": {
+    "oem_strings": {
       "all_records": [
         {
-          "record_id": "0x0401",
-          "size": "4",
-          "application_identifier": "End Of Table",
-          "Socket Designation": "CPU 1",
-          "Type": "RAM",
-          "Family": "Other",
-          "Manufacturer": "Bochs",
-          "ID": "23 06 00 00 FD FB 8B 07",
-          "Version": "Not Specified",
-          "Voltage": "Unknown",
-          "External Clock": "Unknown",
-          "Max Speed": "2000 MHz",
-          "Current Speed": "2000 MHz",
-          "Status": "No errors detected",
-          "Upgrade": "Other",
-          "L1 Cache Handle": "Not Provided",
-          "L2 Cache Handle": "Not Provided",
-          "L3 Cache Handle": "Not Provided",
-          "Location": "Other",
-          "Use": "System Memory",
-          "Error Correction Type": "Multi-bit ECC",
-          "Maximum Capacity": "1 GB",
-          "Error Information Handle": "0x0308",
-          "Number Of Devices": "1",
-          "Array Handle": "0x1000",
-          "Total Width": "64 bits",
-          "Data Width": "64 bits",
-          "Size": "1024 MB",
-          "Form Factor": "DIMM",
-          "Set": "None",
-          "Locator": "DIMM 0",
-          "Bank Locator": "Not Specified",
-          "Type Detail": "None",
-          "Starting Address": "0x00000000000",
-          "Ending Address": "0x0003FFFFFFF",
-          "Range Size": "1 GB",
-          "Physical Array Handle": "0x1000",
-          "Partition Width": "1",
-          "Physical Device Handle": "0x1100",
-          "Memory Array Mapped Address Handle": "0x1300",
-          "Partition Row Position": "1"
+          "record_id": "0x0002",
+          "size": "11",
+          "application_identifier": "OEM Strings",
+          "String 1": "vboxVer_5.0.6",
+          "String 2": "vboxRev_103037"
         }
       ],
-      "socket_designation": "CPU 1",
-      "type": "RAM",
-      "family": "Other",
-      "manufacturer": "Bochs",
-      "id": "23 06 00 00 FD FB 8B 07",
-      "version": "Not Specified",
-      "voltage": "Unknown",
-      "external_clock": "Unknown",
-      "max_speed": "2000 MHz",
-      "current_speed": "2000 MHz",
-      "status": "No errors detected",
-      "upgrade": "Other",
-      "l1_cache_handle": "Not Provided",
-      "l2_cache_handle": "Not Provided",
-      "l3_cache_handle": "Not Provided",
-      "location": "Other",
-      "use": "System Memory",
-      "error_correction_type": "Multi-bit ECC",
-      "maximum_capacity": "1 GB",
-      "error_information_handle": "0x0308",
-      "number_of_devices": "1",
-      "array_handle": "0x1000",
-      "total_width": "64 bits",
-      "data_width": "64 bits",
-      "size": "1024 MB",
-      "form_factor": "DIMM",
-      "set": "None",
-      "locator": "DIMM 0",
-      "bank_locator": "Not Specified",
-      "type_detail": "None",
-      "starting_address": "0x00000000000",
-      "ending_address": "0x0003FFFFFFF",
-      "range_size": "1 GB",
-      "physical_array_handle": "0x1000",
-      "partition_width": "1",
-      "physical_device_handle": "0x1100",
-      "memory_array_mapped_address_handle": "0x1300",
-      "partition_row_position": "1"
+      "string_1": "vboxVer_5.0.6",
+      "string_2": "vboxRev_103037"
     }
   },
-  "ohai_time": 1398102925.40692,
-  "command": {
-    "ps": "ps -ef"
-  },
   "filesystem": {
-    "/dev/vda": {
-      "kb_size": "30832636",
-      "kb_used": "1617276",
-      "kb_available": "27626112",
-      "percent_used": "6%",
+    "/dev/mapper/1404--vg-root": {
+      "kb_size": "10947840",
+      "kb_used": "2623860",
+      "kb_available": "7744808",
+      "percent_used": "26%",
       "mount": "/",
+      "total_inodes": "704512",
+      "inodes_used": "173279",
+      "inodes_available": "531233",
+      "inodes_percent_used": "25%",
       "fs_type": "ext4",
       "mount_options": [
         "rw",
         "errors=remount-ro"
       ],
-      "uuid": "689c818c-54b4-420f-8912-7b2163d5b349",
-      "label": "DOROOT"
+      "uuid": "f9666dd5-9a5a-4958-a37d-968cf3243336"
     },
     "none": {
       "kb_size": "102400",
@@ -280,17 +311,25 @@
       "kb_available": "102400",
       "percent_used": "0%",
       "mount": "/sys/fs/pstore",
+      "total_inodes": "127225",
+      "inodes_used": "2",
+      "inodes_available": "127223",
+      "inodes_percent_used": "1%",
       "fs_type": "pstore",
       "mount_options": [
         "rw"
       ]
     },
     "udev": {
-      "kb_size": "498172",
-      "kb_used": "12",
-      "kb_available": "498160",
+      "kb_size": "497656",
+      "kb_used": "4",
+      "kb_available": "497652",
       "percent_used": "1%",
       "mount": "/dev",
+      "total_inodes": "124414",
+      "inodes_used": "458",
+      "inodes_available": "123956",
+      "inodes_percent_used": "1%",
       "fs_type": "devtmpfs",
       "mount_options": [
         "rw",
@@ -298,11 +337,15 @@
       ]
     },
     "tmpfs": {
-      "kb_size": "101796",
-      "kb_used": "316",
-      "kb_available": "101480",
+      "kb_size": "101780",
+      "kb_used": "416",
+      "kb_available": "101364",
       "percent_used": "1%",
       "mount": "/run",
+      "total_inodes": "127225",
+      "inodes_used": "388",
+      "inodes_available": "126837",
+      "inodes_percent_used": "1%",
       "fs_type": "tmpfs",
       "mount_options": [
         "rw",
@@ -311,6 +354,22 @@
         "size=10%",
         "mode=0755"
       ]
+    },
+    "/dev/sda1": {
+      "kb_size": "240972",
+      "kb_used": "138187",
+      "kb_available": "90344",
+      "percent_used": "61%",
+      "mount": "/boot",
+      "total_inodes": "62248",
+      "inodes_used": "317",
+      "inodes_available": "61931",
+      "inodes_percent_used": "1%",
+      "fs_type": "ext2",
+      "mount_options": [
+        "rw"
+      ],
+      "uuid": "8c399033-7317-4bd9-8d78-87b97067268b"
     },
     "proc": {
       "mount": "/proc",
@@ -355,40 +414,43 @@
         "name=systemd"
       ]
     },
+    "/dev/sda5": {
+      "fs_type": "LVM2_member",
+      "uuid": "3MomGD-ypDD-cxs5-4tgj-I3OU-Raeq-BUO2cF"
+    },
+    "/dev/mapper/1404--vg-swap_1": {
+      "fs_type": "swap",
+      "uuid": "47378c47-2386-4d4c-8756-d1eec05f193d"
+    },
     "rootfs": {
       "mount": "/",
       "fs_type": "rootfs",
       "mount_options": [
         "rw"
       ]
-    },
-    "/dev/disk/by-label/DOROOT": {
-      "mount": "/",
-      "fs_type": "ext4",
-      "mount_options": [
-        "rw",
-        "relatime",
-        "errors=remount-ro",
-        "data=ordered"
-      ]
     }
   },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "ohai_time": 1445839848.4040508,
   "languages": {
     "ruby": {
       "bin_dir": "/usr/local/bin",
       "gem_bin": "/usr/local/bin/gem",
       "gems_dir": "/usr/local/gems",
       "ruby_bin": "/usr/local/bin/ruby"
-    }
+    },
+    "powershell": null
   },
   "chef_packages": {
     "chef": {
-      "version": "11.10.4",
-      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+      "version": "12.5.1",
+      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
     },
     "ohai": {
-      "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "version": "8.7.0",
+      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {
@@ -496,6 +558,6 @@
     "total": 1
   },
   "memory": {
-    "total": "524288kB"
+    "total": "1024MB"
   }
 }


### PR DESCRIPTION
Update these platforms with freshly installed hosts with the latest Ohai.  This adds missing DMI data on Fedora and changes how memory is output on Ubuntu