### PR TITLE
Make chef/ohai a development dep

### DIFF
--- a/fauxhai.gemspec
+++ b/fauxhai.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'net-ssh'
-  spec.add_runtime_dependency 'chef', '~> 12.0'
-  spec.add_runtime_dependency 'ohai', '~> 8.5'
 
+  spec.add_development_dependency 'chef', '~> 12.0'
+  spec.add_development_dependency 'ohai', '~> 8.5'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Fauxhai 3 can't be included in chefspec at the moment due to the Chef 12
dep.  Doing so would require us to remove Chef 11 support from
Chefspec. Chef 11 is still supported so that's not an acceptable option.
Since Ohai / Chef are only needed for dumping new platforms we should
move those to dev deps.