### PR TITLE
remove extra `d` from line 53

### DIFF
--- a/lib/fauxhai/platforms/windows/2012.json
+++ b/lib/fauxhai/platforms/windows/2012.json
@@ -50,7 +50,7 @@
       "locale": "0409",
       "manufacturer": "Microsoft Corporation",
       "max_number_of_processes": -1,
-      "max_process_memory_size": "8589934464", d
+      "max_process_memory_size": "8589934464",
       "mui_languages": [
         "en-US"
       ],


### PR DESCRIPTION
This is breaking the ChefSpec for most of the windows focused cookbooks in Travis.