### PR TITLE
Make checking and pulling from Github optional

### DIFF
--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -23,8 +23,7 @@ module Fauxhai
     # @option options [String] :edge
     #   whether to try loading from Github 
     def initialize(options = {}, &override_attributes)
-      @options = options
-      @options[:edge] = true 
+      @options = { edge: true }.merge(options)
 
       @data = fauxhai_data
       yield(@data) if block_given?

--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -20,8 +20,11 @@ module Fauxhai
     #   the version of the platform to mock
     # @option options [String] :path
     #   the path to a local JSON file
+    # @option options [String] :edge
+    #   whether to try loading from Github 
     def initialize(options = {}, &override_attributes)
       @options = options
+      @options[:edge] = true 
 
       @data = fauxhai_data
       yield(@data) if block_given?
@@ -54,7 +57,7 @@ module Fauxhai
 
         if File.exists?(filepath)
           JSON.parse( File.read(filepath) )
-        elsif
+        elsif !@options[:edge]
           # Try loading from github (in case someone submitted a PR with a new file, but we haven't
           # yet updated the gem version). Cache the response locally so it's faster next time.
           begin
@@ -73,6 +76,9 @@ module Fauxhai
           else
             raise Fauxhai::Exception::InvalidPlatform.new("Could not find platform '#{platform}/#{version}' in any of the sources!")
           end
+        else
+          raise Fauxhai::Exception::InvalidPlatform.new("Could not find platform '#{platform}/#{version}' in any of the s
+ources!") 
         end
       end.call
     end


### PR DESCRIPTION
In order to test in isolation without a dependency on a network
connection or having to set a proxy (if behind a corporate firewall)
to reach Github, make checking and pulling from Github optional. Add
an :edge attribute (default true) to retain current functionality.
