### PR TITLE
Mock out empty virtualization mash

### DIFF
--- a/lib/fauxhai/platforms/aix/6.1.json
+++ b/lib/fauxhai/platforms/aix/6.1.json
@@ -674,5 +674,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/aix/7.1.json
+++ b/lib/fauxhai/platforms/aix/7.1.json
@@ -683,5 +683,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/amazon/2013.09.json
+++ b/lib/fauxhai/platforms/amazon/2013.09.json
@@ -317,5 +317,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/amazon/2014.03.json
+++ b/lib/fauxhai/platforms/amazon/2014.03.json
@@ -316,5 +316,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/amazon/2014.09.json
+++ b/lib/fauxhai/platforms/amazon/2014.09.json
@@ -387,5 +387,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/amazon/2015.03.json
+++ b/lib/fauxhai/platforms/amazon/2015.03.json
@@ -321,5 +321,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/amazon/2015.09.json
+++ b/lib/fauxhai/platforms/amazon/2015.09.json
@@ -330,5 +330,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/arch/3.10.5-1-ARCH.json
+++ b/lib/fauxhai/platforms/arch/3.10.5-1-ARCH.json
@@ -519,5 +519,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.0.json
+++ b/lib/fauxhai/platforms/centos/5.0.json
@@ -708,5 +708,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.1.json
+++ b/lib/fauxhai/platforms/centos/5.1.json
@@ -728,5 +728,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.10.json
+++ b/lib/fauxhai/platforms/centos/5.10.json
@@ -880,5 +880,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.11.json
+++ b/lib/fauxhai/platforms/centos/5.11.json
@@ -746,5 +746,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.2.json
+++ b/lib/fauxhai/platforms/centos/5.2.json
@@ -740,5 +740,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.3.json
+++ b/lib/fauxhai/platforms/centos/5.3.json
@@ -768,5 +768,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.4.json
+++ b/lib/fauxhai/platforms/centos/5.4.json
@@ -772,5 +772,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.5.json
+++ b/lib/fauxhai/platforms/centos/5.5.json
@@ -788,5 +788,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.6.json
+++ b/lib/fauxhai/platforms/centos/5.6.json
@@ -872,5 +872,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.7.json
+++ b/lib/fauxhai/platforms/centos/5.7.json
@@ -876,5 +876,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.8.json
+++ b/lib/fauxhai/platforms/centos/5.8.json
@@ -880,5 +880,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/5.9.json
+++ b/lib/fauxhai/platforms/centos/5.9.json
@@ -880,5 +880,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/6.0.json
+++ b/lib/fauxhai/platforms/centos/6.0.json
@@ -633,5 +633,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/6.1.json
+++ b/lib/fauxhai/platforms/centos/6.1.json
@@ -631,5 +631,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/6.2.json
+++ b/lib/fauxhai/platforms/centos/6.2.json
@@ -631,5 +631,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/6.3.json
+++ b/lib/fauxhai/platforms/centos/6.3.json
@@ -627,5 +627,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/6.4.json
+++ b/lib/fauxhai/platforms/centos/6.4.json
@@ -620,5 +620,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/6.5.json
+++ b/lib/fauxhai/platforms/centos/6.5.json
@@ -609,5 +609,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/6.6.json
+++ b/lib/fauxhai/platforms/centos/6.6.json
@@ -609,5 +609,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/6.7.json
+++ b/lib/fauxhai/platforms/centos/6.7.json
@@ -613,5 +613,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/7.0.1406.json
+++ b/lib/fauxhai/platforms/centos/7.0.1406.json
@@ -813,5 +813,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/7.0.json
+++ b/lib/fauxhai/platforms/centos/7.0.json
@@ -813,5 +813,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/7.1.1503.json
+++ b/lib/fauxhai/platforms/centos/7.1.1503.json
@@ -813,5 +813,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/centos/7.2.1511.json
+++ b/lib/fauxhai/platforms/centos/7.2.1511.json
@@ -702,5 +702,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/debian/7.6.json
+++ b/lib/fauxhai/platforms/debian/7.6.json
@@ -590,5 +590,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/debian/7.7.json
+++ b/lib/fauxhai/platforms/debian/7.7.json
@@ -633,5 +633,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/debian/7.8.json
+++ b/lib/fauxhai/platforms/debian/7.8.json
@@ -633,5 +633,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/debian/7.9.json
+++ b/lib/fauxhai/platforms/debian/7.9.json
@@ -672,5 +672,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/debian/8.0.json
+++ b/lib/fauxhai/platforms/debian/8.0.json
@@ -679,5 +679,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/debian/8.1.json
+++ b/lib/fauxhai/platforms/debian/8.1.json
@@ -679,5 +679,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/debian/8.2.json
+++ b/lib/fauxhai/platforms/debian/8.2.json
@@ -779,5 +779,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/debian/stretch/sid.json
+++ b/lib/fauxhai/platforms/debian/stretch/sid.json
@@ -609,5 +609,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/dragonfly4/4.2-RELEASE.json
+++ b/lib/fauxhai/platforms/dragonfly4/4.2-RELEASE.json
@@ -152,5 +152,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/fedora/18.json
+++ b/lib/fauxhai/platforms/fedora/18.json
@@ -463,5 +463,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/fedora/19.json
+++ b/lib/fauxhai/platforms/fedora/19.json
@@ -463,5 +463,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/fedora/20.json
+++ b/lib/fauxhai/platforms/fedora/20.json
@@ -431,5 +431,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/fedora/21.json
+++ b/lib/fauxhai/platforms/fedora/21.json
@@ -707,5 +707,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/fedora/22.json
+++ b/lib/fauxhai/platforms/fedora/22.json
@@ -751,5 +751,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/fedora/23.json
+++ b/lib/fauxhai/platforms/fedora/23.json
@@ -755,5 +755,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/freebsd/10.0.json
+++ b/lib/fauxhai/platforms/freebsd/10.0.json
@@ -326,5 +326,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/freebsd/10.1.json
+++ b/lib/fauxhai/platforms/freebsd/10.1.json
@@ -313,5 +313,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/freebsd/10.2.json
+++ b/lib/fauxhai/platforms/freebsd/10.2.json
@@ -313,5 +313,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/freebsd/9.1.json
+++ b/lib/fauxhai/platforms/freebsd/9.1.json
@@ -313,5 +313,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/freebsd/9.2.json
+++ b/lib/fauxhai/platforms/freebsd/9.2.json
@@ -313,5 +313,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/freebsd/9.3.json
+++ b/lib/fauxhai/platforms/freebsd/9.3.json
@@ -313,5 +313,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/ios_xr/6.0.0.14I.json
+++ b/lib/fauxhai/platforms/ios_xr/6.0.0.14I.json
@@ -339,5 +339,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/mac_os_x/10.10.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.10.json
@@ -855,5 +855,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/mac_os_x/10.11.1.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.11.1.json
@@ -854,5 +854,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/nexus/5.json
+++ b/lib/fauxhai/platforms/nexus/5.json
@@ -297,5 +297,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/omnios/151014.json
+++ b/lib/fauxhai/platforms/omnios/151014.json
@@ -2419,5 +2419,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/opensuse/12.3.json
+++ b/lib/fauxhai/platforms/opensuse/12.3.json
@@ -611,5 +611,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/opensuse/13.1.json
+++ b/lib/fauxhai/platforms/opensuse/13.1.json
@@ -562,5 +562,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/opensuse/13.2.json
+++ b/lib/fauxhai/platforms/opensuse/13.2.json
@@ -644,5 +644,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/opensuse/42.1.json
+++ b/lib/fauxhai/platforms/opensuse/42.1.json
@@ -542,5 +542,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/oracle/6.6.json
+++ b/lib/fauxhai/platforms/oracle/6.6.json
@@ -375,5 +375,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/oracle/7.0.json
+++ b/lib/fauxhai/platforms/oracle/7.0.json
@@ -625,5 +625,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/oracle/7.1.json
+++ b/lib/fauxhai/platforms/oracle/7.1.json
@@ -819,5 +819,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/redhat/6.6.json
+++ b/lib/fauxhai/platforms/redhat/6.6.json
@@ -517,5 +517,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/redhat/7.1.json
+++ b/lib/fauxhai/platforms/redhat/7.1.json
@@ -744,5 +744,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/slackware/14.1.json
+++ b/lib/fauxhai/platforms/slackware/14.1.json
@@ -368,5 +368,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/suse/12.0.json
+++ b/lib/fauxhai/platforms/suse/12.0.json
@@ -702,5 +702,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/ubuntu/12.04.json
+++ b/lib/fauxhai/platforms/ubuntu/12.04.json
@@ -503,5 +503,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/ubuntu/14.04.json
+++ b/lib/fauxhai/platforms/ubuntu/14.04.json
@@ -561,5 +561,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/ubuntu/14.10.json
+++ b/lib/fauxhai/platforms/ubuntu/14.10.json
@@ -607,5 +607,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/ubuntu/15.04.json
+++ b/lib/fauxhai/platforms/ubuntu/15.04.json
@@ -641,5 +641,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/ubuntu/15.10.json
+++ b/lib/fauxhai/platforms/ubuntu/15.10.json
@@ -649,5 +649,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/windows/10.json
+++ b/lib/fauxhai/platforms/windows/10.json
@@ -3542,5 +3542,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/windows/2003R2.json
+++ b/lib/fauxhai/platforms/windows/2003R2.json
@@ -7884,5 +7884,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/windows/2008R2.json
+++ b/lib/fauxhai/platforms/windows/2008R2.json
@@ -5917,5 +5917,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/windows/2012.json
+++ b/lib/fauxhai/platforms/windows/2012.json
@@ -3573,5 +3573,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/windows/2012R2.json
+++ b/lib/fauxhai/platforms/windows/2012R2.json
@@ -3767,5 +3767,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/windows/8.1.json
+++ b/lib/fauxhai/platforms/windows/8.1.json
@@ -3509,5 +3509,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/windows/8.json
+++ b/lib/fauxhai/platforms/windows/8.json
@@ -3923,5 +3923,9 @@
   },
   "memory": {
     "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/runner.rb
+++ b/lib/fauxhai/runner.rb
@@ -238,9 +238,7 @@ module Fauxhai
 
     def virtualization
       {
-        'systems' => {},
-        'system' => nil,
-        'role' => nil
+        'systems' => {}
       }
     end
 

--- a/lib/fauxhai/runner.rb
+++ b/lib/fauxhai/runner.rb
@@ -23,7 +23,8 @@ module Fauxhai
         'uptime' => uptime,
         'uptime_seconds' => uptime_seconds,
         'cpu' => cpu,
-        'memory' => memory
+        'memory' => memory,
+        'virtualization' => virtualization
       )
 
       puts JSON.pretty_generate(result)
@@ -232,6 +233,14 @@ module Fauxhai
     def memory
       {
         'total' => '1048576kB'
+      }
+    end
+
+    def virtualization
+      {
+        'systems' => {},
+        'system' => nil,
+        'role' => nil
       }
     end
 


### PR DESCRIPTION
This resolves spec failures on cookbooks that include build-essential as it's checking the virtualization values now