### PR TITLE
Mock check_packages to an omnibus location

### DIFF
--- a/lib/fauxhai/platforms/aix/6.1.json
+++ b/lib/fauxhai/platforms/aix/6.1.json
@@ -559,11 +559,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.0.0.alpha.0",
-      "chef_root": "/usr/local/gems/chef-12.0.0.alpha.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.0.0.alpha.0/lib"
     },
     "ohai": {
       "version": "7.2.0",
-      "ohai_root": "/usr/local/gems/ohai-7.2.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.2.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/aix/7.1.json
+++ b/lib/fauxhai/platforms/aix/7.1.json
@@ -568,11 +568,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.0.0.alpha.0",
-      "chef_root": "/usr/local/gems/chef-12.0.0.alpha.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.0.0.alpha.0/lib"
     },
     "ohai": {
       "version": "7.2.0",
-      "ohai_root": "/usr/local/gems/ohai-7.2.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.2.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/amazon/2012.09.json
+++ b/lib/fauxhai/platforms/amazon/2012.09.json
@@ -194,11 +194,11 @@
   "chef_packages": {
     "chef": {
       "version": "10.16.2",
-      "chef_root": "/usr/local/gems/chef-10.16.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-10.16.2/lib"
     },
     "ohai": {
       "version": "6.14.0",
-      "ohai_root": "/usr/local/gems/ohai-6.14.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.14.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/amazon/2013.09.json
+++ b/lib/fauxhai/platforms/amazon/2013.09.json
@@ -203,11 +203,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.4",
-      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.4/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/amazon/2014.03.json
+++ b/lib/fauxhai/platforms/amazon/2014.03.json
@@ -202,11 +202,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.4",
-      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.4/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/amazon/2014.09.json
+++ b/lib/fauxhai/platforms/amazon/2014.09.json
@@ -272,11 +272,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.16.4",
-      "chef_root": "/usr/local/gems/chef-11.16.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.16.4/lib"
     },
     "ohai": {
       "version": "7.4.0",
-      "ohai_root": "/usr/local/gems/ohai-7.4.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.4.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/amazon/2015.03.json
+++ b/lib/fauxhai/platforms/amazon/2015.03.json
@@ -207,11 +207,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.3.0",
-      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.3.0/lib"
     },
     "ohai": {
       "version": "8.4.0",
-      "ohai_root": "/usr/local/gems/ohai-8.4.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.4.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/amazon/2015.09.json
+++ b/lib/fauxhai/platforms/amazon/2015.09.json
@@ -216,11 +216,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/arch/3.10.5-1-ARCH.json
+++ b/lib/fauxhai/platforms/arch/3.10.5-1-ARCH.json
@@ -404,11 +404,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.16.4",
-      "chef_root": "/usr/local/gems/chef-11.16.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.16.4/lib"
     },
     "ohai": {
       "version": "7.4.0",
-      "ohai_root": "/usr/local/gems/ohai-7.4.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.4.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.0.json
+++ b/lib/fauxhai/platforms/centos/5.0.json
@@ -594,11 +594,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.1.json
+++ b/lib/fauxhai/platforms/centos/5.1.json
@@ -614,11 +614,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.10.json
+++ b/lib/fauxhai/platforms/centos/5.10.json
@@ -766,11 +766,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.11.json
+++ b/lib/fauxhai/platforms/centos/5.11.json
@@ -632,11 +632,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.2.json
+++ b/lib/fauxhai/platforms/centos/5.2.json
@@ -626,11 +626,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.3.json
+++ b/lib/fauxhai/platforms/centos/5.3.json
@@ -654,11 +654,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.4.json
+++ b/lib/fauxhai/platforms/centos/5.4.json
@@ -658,11 +658,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.5.json
+++ b/lib/fauxhai/platforms/centos/5.5.json
@@ -674,11 +674,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.6.json
+++ b/lib/fauxhai/platforms/centos/5.6.json
@@ -758,11 +758,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.7.json
+++ b/lib/fauxhai/platforms/centos/5.7.json
@@ -762,11 +762,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.8.json
+++ b/lib/fauxhai/platforms/centos/5.8.json
@@ -766,11 +766,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/5.9.json
+++ b/lib/fauxhai/platforms/centos/5.9.json
@@ -766,11 +766,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/6.0.json
+++ b/lib/fauxhai/platforms/centos/6.0.json
@@ -519,11 +519,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/6.1.json
+++ b/lib/fauxhai/platforms/centos/6.1.json
@@ -517,11 +517,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/6.2.json
+++ b/lib/fauxhai/platforms/centos/6.2.json
@@ -517,11 +517,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/6.3.json
+++ b/lib/fauxhai/platforms/centos/6.3.json
@@ -513,11 +513,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/6.4.json
+++ b/lib/fauxhai/platforms/centos/6.4.json
@@ -506,11 +506,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/6.5.json
+++ b/lib/fauxhai/platforms/centos/6.5.json
@@ -495,11 +495,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/6.6.json
+++ b/lib/fauxhai/platforms/centos/6.6.json
@@ -495,11 +495,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/6.7.json
+++ b/lib/fauxhai/platforms/centos/6.7.json
@@ -499,11 +499,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/7.0.1406.json
+++ b/lib/fauxhai/platforms/centos/7.0.1406.json
@@ -699,11 +699,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/7.0.json
+++ b/lib/fauxhai/platforms/centos/7.0.json
@@ -699,11 +699,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/7.1.1503.json
+++ b/lib/fauxhai/platforms/centos/7.1.1503.json
@@ -699,11 +699,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/centos/7.2.1511.json
+++ b/lib/fauxhai/platforms/centos/7.2.1511.json
@@ -588,11 +588,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.6.0",
-      "chef_root": "/usr/local/gems/chef-12.6.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.6.0/lib"
     },
     "ohai": {
       "version": "8.8.1",
-      "ohai_root": "/usr/local/gems/ohai-8.8.1/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.8.1/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/6.0.5.json
+++ b/lib/fauxhai/platforms/debian/6.0.5.json
@@ -189,11 +189,11 @@
   "chef_packages": {
     "chef": {
       "version": "10.14.4",
-      "chef_root": "/usr/local/gems/chef-10.14.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-10.14.4/lib"
     },
     "ohai": {
       "version": "6.14.0",
-      "ohai_root": "/usr/local/gems/ohai-6.14.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.14.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/7.0.json
+++ b/lib/fauxhai/platforms/debian/7.0.json
@@ -494,11 +494,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.4.4",
-      "chef_root": "/usr/local/gems/chef-11.4.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.4.4/lib"
     },
     "ohai": {
       "version": "6.16.0",
-      "ohai_root": "/usr/local/gems/ohai-6.16.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.16.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/7.1.json
+++ b/lib/fauxhai/platforms/debian/7.1.json
@@ -494,11 +494,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.4.4",
-      "chef_root": "/usr/local/gems/chef-11.4.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.4.4/lib"
     },
     "ohai": {
       "version": "6.16.0",
-      "ohai_root": "/usr/local/gems/ohai-6.16.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.16.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/7.2.json
+++ b/lib/fauxhai/platforms/debian/7.2.json
@@ -278,11 +278,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.2",
-      "chef_root": "/usr/local/gems/chef-11.8.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.2/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/7.4.json
+++ b/lib/fauxhai/platforms/debian/7.4.json
@@ -313,11 +313,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.0",
-      "chef_root": "/usr/local/gems/chef-11.10.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.0/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/7.5.json
+++ b/lib/fauxhai/platforms/debian/7.5.json
@@ -2565,11 +2565,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.12.4",
-      "chef_root": "/usr/local/gems/chef-11.12.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.4/lib"
     },
     "ohai": {
       "version": "7.0.4",
-      "ohai_root": "/usr/local/gems/ohai-7.0.4/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.4/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/7.6.json
+++ b/lib/fauxhai/platforms/debian/7.6.json
@@ -476,11 +476,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.12.8",
-      "chef_root": "/usr/local/gems/chef-11.12.8/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.8/lib"
     },
     "ohai": {
       "version": "7.0.4",
-      "ohai_root": "/usr/local/gems/ohai-7.0.4/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.4/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/7.7.json
+++ b/lib/fauxhai/platforms/debian/7.7.json
@@ -519,11 +519,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.0.3",
-      "chef_root": "/usr/local/gems/chef-12.0.3/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.0.3/lib"
     },
     "ohai": {
       "version": "8.0.1",
-      "ohai_root": "/usr/local/gems/ohai-8.0.1/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.0.1/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/7.8.json
+++ b/lib/fauxhai/platforms/debian/7.8.json
@@ -519,11 +519,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.0.3",
-      "chef_root": "/usr/local/gems/chef-12.0.3/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.0.3/lib"
     },
     "ohai": {
       "version": "8.0.1",
-      "ohai_root": "/usr/local/gems/ohai-8.0.1/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.0.1/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/7.9.json
+++ b/lib/fauxhai/platforms/debian/7.9.json
@@ -558,11 +558,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/8.0.json
+++ b/lib/fauxhai/platforms/debian/8.0.json
@@ -565,11 +565,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.3.0",
-      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.3.0/lib"
     },
     "ohai": {
       "version": "8.4.0",
-      "ohai_root": "/usr/local/gems/ohai-8.4.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.4.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/8.1.json
+++ b/lib/fauxhai/platforms/debian/8.1.json
@@ -565,11 +565,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.3.0",
-      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.3.0/lib"
     },
     "ohai": {
       "version": "8.4.0",
-      "ohai_root": "/usr/local/gems/ohai-8.4.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.4.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/8.2.json
+++ b/lib/fauxhai/platforms/debian/8.2.json
@@ -665,11 +665,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/jessie/sid.json
+++ b/lib/fauxhai/platforms/debian/jessie/sid.json
@@ -467,11 +467,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.4",
-      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.4/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/debian/stretch/sid.json
+++ b/lib/fauxhai/platforms/debian/stretch/sid.json
@@ -495,11 +495,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.3.0",
-      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.3.0/lib"
     },
     "ohai": {
       "version": "8.6.0.alpha.1",
-      "ohai_root": "/usr/local/gems/ohai-8.6.0.alpha.1/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.6.0.alpha.1/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/dragonfly4/4.2-RELEASE.json
+++ b/lib/fauxhai/platforms/dragonfly4/4.2-RELEASE.json
@@ -38,11 +38,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.4.1",
-      "chef_root": "/usr/local/gems/chef-12.4.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.4.1/lib"
     },
     "ohai": {
       "version": "8.5.1",
-      "ohai_root": "/usr/local/gems/ohai-8.5.1/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.5.1/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/fedora/18.json
+++ b/lib/fauxhai/platforms/fedora/18.json
@@ -349,11 +349,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.4.0",
-      "chef_root": "/usr/local/gems/chef-11.4.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.4.0/lib"
     },
     "ohai": {
       "version": "6.16.0",
-      "ohai_root": "/usr/local/gems/ohai-6.16.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.16.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/fedora/19.json
+++ b/lib/fauxhai/platforms/fedora/19.json
@@ -349,11 +349,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.4",
-      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.4/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/fedora/20.json
+++ b/lib/fauxhai/platforms/fedora/20.json
@@ -317,11 +317,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.4",
-      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.4/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/fedora/21.json
+++ b/lib/fauxhai/platforms/fedora/21.json
@@ -593,11 +593,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/fedora/22.json
+++ b/lib/fauxhai/platforms/fedora/22.json
@@ -637,11 +637,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/fedora/23.json
+++ b/lib/fauxhai/platforms/fedora/23.json
@@ -641,11 +641,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.6.0",
-      "chef_root": "/usr/local/gems/chef-12.6.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.6.0/lib"
     },
     "ohai": {
       "version": "8.8.1",
-      "ohai_root": "/usr/local/gems/ohai-8.8.1/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.8.1/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/freebsd/10.0.json
+++ b/lib/fauxhai/platforms/freebsd/10.0.json
@@ -212,11 +212,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.12.2",
-      "chef_root": "/usr/local/gems/chef-11.12.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.2/lib"
     },
     "ohai": {
       "version": "7.0.2",
-      "ohai_root": "/usr/local/gems/ohai-7.0.2/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.2/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/freebsd/10.1.json
+++ b/lib/fauxhai/platforms/freebsd/10.1.json
@@ -199,11 +199,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/freebsd/10.2.json
+++ b/lib/fauxhai/platforms/freebsd/10.2.json
@@ -199,11 +199,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/freebsd/8.4.json
+++ b/lib/fauxhai/platforms/freebsd/8.4.json
@@ -247,11 +247,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.12.2",
-      "chef_root": "/usr/local/gems/chef-11.12.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.2/lib"
     },
     "ohai": {
       "version": "7.0.2",
-      "ohai_root": "/usr/local/gems/ohai-7.0.2/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.2/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/freebsd/9.1.json
+++ b/lib/fauxhai/platforms/freebsd/9.1.json
@@ -199,11 +199,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/freebsd/9.2.json
+++ b/lib/fauxhai/platforms/freebsd/9.2.json
@@ -199,11 +199,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/freebsd/9.3.json
+++ b/lib/fauxhai/platforms/freebsd/9.3.json
@@ -199,11 +199,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/gentoo/2.1.json
+++ b/lib/fauxhai/platforms/gentoo/2.1.json
@@ -303,11 +303,11 @@
   "chef_packages": {
     "chef": {
       "version": "10.24.0",
-      "chef_root": "/usr/local/gems/chef-10.24.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-10.24.0/lib"
     },
     "ohai": {
       "version": "6.16.0",
-      "ohai_root": "/usr/local/gems/ohai-6.16.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.16.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/ios_xr/6.0.0.14I.json
+++ b/lib/fauxhai/platforms/ios_xr/6.0.0.14I.json
@@ -225,11 +225,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.3.0",
-      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.3.0/lib"
     },
     "ohai": {
       "version": "8.6.0",
-      "ohai_root": "/usr/local/gems/ohai-8.6.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.6.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/mac_os_x/10.10.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.10.json
@@ -740,11 +740,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.16.4",
-      "chef_root": "/usr/local/gems/chef-11.16.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.16.4/lib"
     },
     "ohai": {
       "version": "7.4.0",
-      "ohai_root": "/usr/local/gems/ohai-7.4.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.4.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/mac_os_x/10.11.1.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.11.1.json
@@ -740,11 +740,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/mac_os_x/10.6.8.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.6.8.json
@@ -735,11 +735,11 @@
   "chef_packages": {
     "chef": {
       "version": "10.12.0",
-      "chef_root": "/usr/local/gems/chef-10.12.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-10.12.0/lib"
     },
     "ohai": {
       "version": "6.14.0",
-      "ohai_root": "/usr/local/gems/ohai-6.14.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.14.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/mac_os_x/10.7.4.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.7.4.json
@@ -687,11 +687,11 @@
   "chef_packages": {
     "chef": {
       "version": "10.12.0",
-      "chef_root": "/usr/local/gems/chef-10.12.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-10.12.0/lib"
     },
     "ohai": {
       "version": "6.14.0",
-      "ohai_root": "/usr/local/gems/ohai-6.14.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.14.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/mac_os_x/10.8.2.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.8.2.json
@@ -644,11 +644,11 @@
   "chef_packages": {
     "chef": {
       "version": "10.16.2",
-      "chef_root": "/usr/local/gems/chef-10.16.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-10.16.2/lib"
     },
     "ohai": {
       "version": "6.14.0",
-      "ohai_root": "/usr/local/gems/ohai-6.14.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.14.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/mac_os_x/10.9.2.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.9.2.json
@@ -691,11 +691,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.2",
-      "chef_root": "/usr/local/gems/chef-11.10.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.2/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/nexus/5.json
+++ b/lib/fauxhai/platforms/nexus/5.json
@@ -183,11 +183,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.3.0",
-      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.3.0/lib"
     },
     "ohai": {
       "version": "8.6.0",
-      "ohai_root": "/usr/local/gems/ohai-8.6.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.6.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/omnios/151002.json
+++ b/lib/fauxhai/platforms/omnios/151002.json
@@ -2269,11 +2269,11 @@
   "chef_packages": {
     "chef": {
       "version": "10.14.0",
-      "chef_root": "/usr/local/gems/chef-10.14.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-10.14.0/lib"
     },
     "ohai": {
       "version": "0.6.12",
-      "ohai_root": "/usr/local/gems/ohai-0.6.12/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-0.6.12/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/omnios/151006.json
+++ b/lib/fauxhai/platforms/omnios/151006.json
@@ -1834,11 +1834,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.4",
-      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.4/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/omnios/151008.json
+++ b/lib/fauxhai/platforms/omnios/151008.json
@@ -2109,11 +2109,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.12.4",
-      "chef_root": "/usr/local/gems/chef-11.12.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.4/lib"
     },
     "ohai": {
       "version": "7.0.4",
-      "ohai_root": "/usr/local/gems/ohai-7.0.4/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.4/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/omnios/151014.json
+++ b/lib/fauxhai/platforms/omnios/151014.json
@@ -2305,11 +2305,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.18.6",
-      "chef_root": "/usr/local/gems/chef-11.18.6/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.18.6/lib"
     },
     "ohai": {
       "version": "7.4.1",
-      "ohai_root": "/usr/local/gems/ohai-7.4.1/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.4.1/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/openbsd/5.4.json
+++ b/lib/fauxhai/platforms/openbsd/5.4.json
@@ -114,11 +114,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.2",
-      "chef_root": "/usr/local/gems/chef-11.8.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.2/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/opensuse/12.3.json
+++ b/lib/fauxhai/platforms/opensuse/12.3.json
@@ -497,11 +497,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/opensuse/13.1.json
+++ b/lib/fauxhai/platforms/opensuse/13.1.json
@@ -448,11 +448,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/opensuse/13.2.json
+++ b/lib/fauxhai/platforms/opensuse/13.2.json
@@ -530,11 +530,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/opensuse/42.1.json
+++ b/lib/fauxhai/platforms/opensuse/42.1.json
@@ -428,11 +428,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.6.0",
-      "chef_root": "/usr/local/gems/chef-12.6.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.6.0/lib"
     },
     "ohai": {
       "version": "8.8.1",
-      "ohai_root": "/usr/local/gems/ohai-8.8.1/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.8.1/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/oracle/5.10.json
+++ b/lib/fauxhai/platforms/oracle/5.10.json
@@ -33,11 +33,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.4",
-      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.4/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/oracle/6.5.json
+++ b/lib/fauxhai/platforms/oracle/6.5.json
@@ -232,11 +232,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.4",
-      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.4/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/oracle/6.6.json
+++ b/lib/fauxhai/platforms/oracle/6.6.json
@@ -261,11 +261,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.3.0",
-      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.3.0/lib"
     },
     "ohai": {
       "version": "8.4.0",
-      "ohai_root": "/usr/local/gems/ohai-8.4.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.4.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/oracle/7.0.json
+++ b/lib/fauxhai/platforms/oracle/7.0.json
@@ -511,11 +511,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.3.0",
-      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.3.0/lib"
     },
     "ohai": {
       "version": "8.4.0",
-      "ohai_root": "/usr/local/gems/ohai-8.4.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.4.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/oracle/7.1.json
+++ b/lib/fauxhai/platforms/oracle/7.1.json
@@ -705,11 +705,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.3.0",
-      "chef_root": "/usr/local/gems/chef-12.3.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.3.0/lib"
     },
     "ohai": {
       "version": "8.3.0",
-      "ohai_root": "/usr/local/gems/ohai-8.3.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.3.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/5.10.json
+++ b/lib/fauxhai/platforms/redhat/5.10.json
@@ -2678,11 +2678,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.2",
-      "chef_root": "/usr/local/gems/chef-11.8.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.2/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/5.6.json
+++ b/lib/fauxhai/platforms/redhat/5.6.json
@@ -2746,11 +2746,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.2",
-      "chef_root": "/usr/local/gems/chef-11.8.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.2/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/5.7.json
+++ b/lib/fauxhai/platforms/redhat/5.7.json
@@ -2849,11 +2849,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.2",
-      "chef_root": "/usr/local/gems/chef-11.8.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.2/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/5.8.json
+++ b/lib/fauxhai/platforms/redhat/5.8.json
@@ -1428,11 +1428,11 @@
   "chef_packages": {
     "chef": {
       "version": "10.12.0",
-      "chef_root": "/usr/local/gems/chef-10.12.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-10.12.0/lib"
     },
     "ohai": {
       "version": "6.14.0",
-      "ohai_root": "/usr/local/gems/ohai-6.14.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.14.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/5.9.json
+++ b/lib/fauxhai/platforms/redhat/5.9.json
@@ -2678,11 +2678,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.2",
-      "chef_root": "/usr/local/gems/chef-11.8.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.2/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/6.0.json
+++ b/lib/fauxhai/platforms/redhat/6.0.json
@@ -2411,11 +2411,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.0",
-      "chef_root": "/usr/local/gems/chef-11.8.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.0/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/6.1.json
+++ b/lib/fauxhai/platforms/redhat/6.1.json
@@ -2415,11 +2415,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.0",
-      "chef_root": "/usr/local/gems/chef-11.8.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.0/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/6.2.json
+++ b/lib/fauxhai/platforms/redhat/6.2.json
@@ -2482,11 +2482,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.2",
-      "chef_root": "/usr/local/gems/chef-11.8.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.2/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/6.3.json
+++ b/lib/fauxhai/platforms/redhat/6.3.json
@@ -2396,11 +2396,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.0",
-      "chef_root": "/usr/local/gems/chef-11.8.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.0/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/6.4.json
+++ b/lib/fauxhai/platforms/redhat/6.4.json
@@ -207,11 +207,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.2",
-      "chef_root": "/usr/local/gems/chef-11.8.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.2/lib"
     },
     "ohai": {
       "version": "7.0.0.rc.0",
-      "ohai_root": "/usr/local/gems/ohai-7.0.0.rc.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.0.rc.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/6.5.json
+++ b/lib/fauxhai/platforms/redhat/6.5.json
@@ -207,11 +207,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.2",
-      "chef_root": "/usr/local/gems/chef-11.8.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.2/lib"
     },
     "ohai": {
       "version": "7.0.0.rc.0",
-      "ohai_root": "/usr/local/gems/ohai-7.0.0.rc.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.0.rc.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/6.6.json
+++ b/lib/fauxhai/platforms/redhat/6.6.json
@@ -403,11 +403,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.2.1",
-      "chef_root": "/usr/local/gems/chef-12.2.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.2.1/lib"
     },
     "ohai": {
       "version": "8.2.0",
-      "ohai_root": "/usr/local/gems/ohai-8.2.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.2.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/7.0.json
+++ b/lib/fauxhai/platforms/redhat/7.0.json
@@ -734,11 +734,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.12.8",
-      "chef_root": "/usr/local/gems/chef-11.12.8/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.8/lib"
     },
     "ohai": {
       "version": "7.0.4",
-      "ohai_root": "/usr/local/gems/ohai-7.0.4/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.4/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/redhat/7.1.json
+++ b/lib/fauxhai/platforms/redhat/7.1.json
@@ -630,11 +630,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.0.3",
-      "chef_root": "/usr/local/gems/chef-12.0.3/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.0.3/lib"
     },
     "ohai": {
       "version": "8.0.1",
-      "ohai_root": "/usr/local/gems/ohai-8.0.1/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.0.1/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/slackware/14.1.json
+++ b/lib/fauxhai/platforms/slackware/14.1.json
@@ -253,11 +253,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.16.4",
-      "chef_root": "/usr/local/gems/chef-11.16.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.16.4/lib"
     },
     "ohai": {
       "version": "7.4.0",
-      "ohai_root": "/usr/local/gems/ohai-7.4.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.4.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/smartos/5.11.json
+++ b/lib/fauxhai/platforms/smartos/5.11.json
@@ -1558,11 +1558,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.0",
-      "chef_root": "/usr/local/gems/chef-11.10.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.0/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/smartos/joyent_20130111T180733Z.json
+++ b/lib/fauxhai/platforms/smartos/joyent_20130111T180733Z.json
@@ -1536,11 +1536,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.4.4",
-      "chef_root": "/usr/local/gems/chef-11.4.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.4.4/lib"
     },
     "ohai": {
       "version": "6.16.0",
-      "ohai_root": "/usr/local/gems/ohai-6.16.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.16.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/solaris2/5.10.json
+++ b/lib/fauxhai/platforms/solaris2/5.10.json
@@ -2325,11 +2325,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.6.0",
-      "chef_root": "/usr/local/gems/chef-12.6.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.6.0/lib"
     },
     "ohai": {
       "version": "8.8.1",
-      "ohai_root": "/usr/local/gems/ohai-8.8.1/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.8.1/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/solaris2/5.11.json
+++ b/lib/fauxhai/platforms/solaris2/5.11.json
@@ -2589,11 +2589,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.12.2",
-      "chef_root": "/usr/local/gems/chef-11.12.2/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.2/lib"
     },
     "ohai": {
       "version": "7.0.2",
-      "ohai_root": "/usr/local/gems/ohai-7.0.2/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.2/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/suse/11.1.json
+++ b/lib/fauxhai/platforms/suse/11.1.json
@@ -2442,11 +2442,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.12.4",
-      "chef_root": "/usr/local/gems/chef-11.12.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.4/lib"
     },
     "ohai": {
       "version": "7.0.4",
-      "ohai_root": "/usr/local/gems/ohai-7.0.4/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.4/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/suse/11.2.json
+++ b/lib/fauxhai/platforms/suse/11.2.json
@@ -2443,11 +2443,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.12.4",
-      "chef_root": "/usr/local/gems/chef-11.12.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.4/lib"
     },
     "ohai": {
       "version": "7.0.4",
-      "ohai_root": "/usr/local/gems/ohai-7.0.4/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.4/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/suse/11.3.json
+++ b/lib/fauxhai/platforms/suse/11.3.json
@@ -2404,11 +2404,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.12.4",
-      "chef_root": "/usr/local/gems/chef-11.12.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.4/lib"
     },
     "ohai": {
       "version": "7.0.4",
-      "ohai_root": "/usr/local/gems/ohai-7.0.4/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.4/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/suse/12.0.json
+++ b/lib/fauxhai/platforms/suse/12.0.json
@@ -588,11 +588,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.0",
-      "chef_root": "/usr/local/gems/chef-11.10.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.0/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/ubuntu/12.04.json
+++ b/lib/fauxhai/platforms/ubuntu/12.04.json
@@ -389,11 +389,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/ubuntu/13.04.json
+++ b/lib/fauxhai/platforms/ubuntu/13.04.json
@@ -2471,11 +2471,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.8.0",
-      "chef_root": "/usr/local/gems/chef-11.8.0/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.8.0/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/ubuntu/13.10.json
+++ b/lib/fauxhai/platforms/ubuntu/13.10.json
@@ -389,11 +389,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.10.4",
-      "chef_root": "/usr/local/gems/chef-11.10.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.10.4/lib"
     },
     "ohai": {
       "version": "6.20.0",
-      "ohai_root": "/usr/local/gems/ohai-6.20.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-6.20.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/ubuntu/14.04.json
+++ b/lib/fauxhai/platforms/ubuntu/14.04.json
@@ -447,11 +447,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/ubuntu/14.10.json
+++ b/lib/fauxhai/platforms/ubuntu/14.10.json
@@ -492,11 +492,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.16.4",
-      "chef_root": "/usr/local/gems/chef-11.16.4/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.16.4/lib"
     },
     "ohai": {
       "version": "7.4.0",
-      "ohai_root": "/usr/local/gems/ohai-7.4.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.4.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/ubuntu/15.04.json
+++ b/lib/fauxhai/platforms/ubuntu/15.04.json
@@ -527,11 +527,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/ubuntu/15.10.json
+++ b/lib/fauxhai/platforms/ubuntu/15.10.json
@@ -535,11 +535,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/windows/10.json
+++ b/lib/fauxhai/platforms/windows/10.json
@@ -3428,11 +3428,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/windows/2003R2.json
+++ b/lib/fauxhai/platforms/windows/2003R2.json
@@ -7769,11 +7769,11 @@
   "chef_packages": {
     "chef": {
       "version": "11.14.6",
-      "chef_root": "/usr/local/gems/chef-11.14.6/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.14.6/lib"
     },
     "ohai": {
       "version": "7.2.4",
-      "ohai_root": "/usr/local/gems/ohai-7.2.4/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.2.4/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/windows/2008R2.json
+++ b/lib/fauxhai/platforms/windows/2008R2.json
@@ -5803,11 +5803,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/windows/2012.json
+++ b/lib/fauxhai/platforms/windows/2012.json
@@ -3459,11 +3459,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/windows/2012R2.json
+++ b/lib/fauxhai/platforms/windows/2012R2.json
@@ -3653,11 +3653,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/windows/8.1.json
+++ b/lib/fauxhai/platforms/windows/8.1.json
@@ -3395,11 +3395,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/platforms/windows/8.json
+++ b/lib/fauxhai/platforms/windows/8.json
@@ -3809,11 +3809,11 @@
   "chef_packages": {
     "chef": {
       "version": "12.5.1",
-      "chef_root": "/usr/local/gems/chef-12.5.1/lib"
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.5.1/lib"
     },
     "ohai": {
       "version": "8.7.0",
-      "ohai_root": "/usr/local/gems/ohai-8.7.0/lib/ohai"
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.7.0/lib/ohai"
     }
   },
   "counters": {

--- a/lib/fauxhai/runner.rb
+++ b/lib/fauxhai/runner.rb
@@ -44,11 +44,11 @@ module Fauxhai
       {
         'chef' => {
           'version' => chef_version,
-          'chef_root' => [gems_dir, "chef-#{chef_version}", 'lib'].join('/')
+          'chef_root' => ['/opt/chef/embedded/lib/ruby/gems/2.1.0/gems', "chef-#{chef_version}", 'lib'].join('/')
         },
         'ohai' => {
           'version' => ohai_version,
-          'ohai_root' => [gems_dir, "ohai-#{ohai_version}", 'lib', 'ohai'].join('/')
+          'ohai_root' => ['/opt/chef/embedded/lib/ruby/gems/2.1.0/gems', "ohai-#{ohai_version}", 'lib', 'ohai'].join('/')
         }
       }
     end


### PR DESCRIPTION
Just about everyone is using Omnibus now.  We should fake out the omnibus location not a gem install location