### PR TITLE
Update Solaris data with Chef12/Ohai 8 output

### DIFF
--- a/lib/fauxhai/platforms/solaris2/5.10.json
+++ b/lib/fauxhai/platforms/solaris2/5.10.json
@@ -2439,9 +2439,14 @@
   "uptime_seconds": 2646450,
   "cpu": {
     "real": 1,
-    "total": 1
+    "total": 1,
+    "cores": 1
   },
   "memory": {
-    "total": "1024MB"
+    "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }

--- a/lib/fauxhai/platforms/solaris2/5.11.json
+++ b/lib/fauxhai/platforms/solaris2/5.11.json
@@ -1,1035 +1,1452 @@
 {
+  "dmi": {
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0",
+          "size": "54",
+          "application_identifier": "BIOS information",
+          "Vendor": "innotek GmbH",
+          "Version String": "VirtualBox",
+          "Release Date": "12/01/2006",
+          "Address Segment": "0xe000",
+          "ROM Size": "131072 bytes",
+          "Image Size": "131072 bytes",
+          "Characteristics": {
+            "SMB_BIOSFL_ISA": "ISA is supported",
+            "SMB_BIOSFL_PCI": "PCI is supported",
+            "SMB_BIOSFL_CDBOOT": "Boot from CD is supported",
+            "SMB_BIOSFL_SELBOOT": "Selectable Boot supported",
+            "SMB_BIOSFL_I9_KBD": "int 0x9 8042 keyboard svcs",
+            "SMB_BIOSFL_I10_CGA": "int 0x10 CGA svcs"
+          },
+          "Characteristics Extension Byte 1": {
+            "SMB_BIOSXB1_ACPI": "ACPI is supported"
+          },
+          "Characteristics Extension Byte 2": "0x0"
+        }
+      ],
+      "vendor": "innotek GmbH",
+      "version_string": "VirtualBox",
+      "release_date": "12/01/2006",
+      "address_segment": "0xe000",
+      "rom_size": "131072 bytes",
+      "image_size": "131072 bytes",
+      "characteristics_extension_byte_2": "0x0"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "1",
+          "size": "72",
+          "application_identifier": "system information",
+          "Manufacturer": "innotek GmbH",
+          "Product": "VirtualBox",
+          "Version": "1.2",
+          "Serial Number": "0",
+          "UUID": "0e07794e-214b-477e-b5fe-c9fe8d58f04b",
+          "Wake-Up Event": "0x6 (power switch)",
+          "SKU Number": "",
+          "Family": "Virtual Machine"
+        }
+      ],
+      "manufacturer": "innotek GmbH",
+      "product": "VirtualBox",
+      "version": "1.2",
+      "serial_number": "0",
+      "uuid": "0e07794e-214b-477e-b5fe-c9fe8d58f04b",
+      "wake_up_event": "0x6 (power switch)",
+      "sku_number": "",
+      "family": "Virtual Machine"
+    },
+    "base_board": {
+      "all_records": [
+        {
+          "record_id": "8",
+          "size": "50",
+          "application_identifier": "base board",
+          "Chassis": "4104649272",
+          "Flags": {
+            "SMB_BBFL_MOTHERBOARD": "board is a motherboard",
+            "SMB_BBFL_NEEDAUX": "auxiliary card or daughter req'd",
+            "SMB_BBFL_REMOVABLE": "board is removable",
+            "SMB_BBFL_HOTSWAP": "board is hot-swappable"
+          },
+          "Board Type": "0x42"
+        }
+      ],
+      "chassis": "4104649272",
+      "board_type": "0x42"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "3",
+          "size": "31",
+          "application_identifier": "system enclosure or chassis",
+          "Manufacturer": "Oracle Corporation",
+          "OEM Data": "0x0",
+          "Lock Present": "N",
+          "Chassis Type": "0x1 (other)",
+          "Boot-Up State": "0x3 (safe)",
+          "Power Supply State": "0x3 (safe)",
+          "Thermal State": "0x3 (safe)",
+          "Chassis Height": "0u",
+          "Power Cords": "0",
+          "Element Records": "0"
+        }
+      ],
+      "manufacturer": "Oracle Corporation",
+      "oem_data": "0x0",
+      "lock_present": "N",
+      "chassis_type": "0x1 (other)",
+      "boot_up_state": "0x3 (safe)",
+      "power_supply_state": "0x3 (safe)",
+      "thermal_state": "0x3 (safe)",
+      "chassis_height": "0u",
+      "power_cords": "0",
+      "element_records": "0"
+    },
+    "oem_strings": {
+      "all_records": [
+        {
+          "record_id": "2",
+          "size": "36",
+          "application_identifier": "OEM string table",
+          "vboxVer_5.0.14": "",
+          "vboxRev_105127": ""
+        }
+      ],
+      "vboxver_5_0_14": "",
+      "vboxrev_105127": ""
+    }
+  },
   "kernel": {
     "name": "SunOS",
     "release": "5.11",
-    "version": "11.1",
+    "version": "11.3",
     "machine": "i86pc",
+    "processor": "i386",
     "os": "SunOS",
     "modules": {
       "specfs": {
         "id": 3,
-        "loadaddr": "fffffffffbc44000",
-        "size": 24344,
+        "loadaddr": "fffffffffbc4f000",
+        "size": 21248,
         "description": "filesystem for specfs"
       },
       "fifofs": {
         "id": 4,
-        "loadaddr": "fffffffffbc49e78",
-        "size": 17576,
+        "loadaddr": "fffffffffbc54260",
+        "size": 15616,
         "description": "filesystem for fifo"
       },
       "dtrace": {
         "id": 5,
-        "loadaddr": "fffffffff8047000",
-        "size": 115336,
+        "loadaddr": "fffffffff7dd8000",
+        "size": 109448,
         "description": "Dynamic Tracing"
       },
       "devfs": {
         "id": 6,
-        "loadaddr": "fffffffffbc4e268",
-        "size": 23864,
+        "loadaddr": "fffffffffbc57ea8",
+        "size": 21168,
         "description": "devices filesystem"
       },
       "dev": {
         "id": 7,
-        "loadaddr": "fffffffffbc53d58",
-        "size": 78808,
+        "loadaddr": "fffffffffbc5cf10",
+        "size": 91200,
         "description": "/dev filesystem"
       },
       "dls": {
         "id": 8,
-        "loadaddr": "fffffffffbc66aa8",
-        "size": 27320,
+        "loadaddr": "fffffffffbc72bb8",
+        "size": 23496,
         "description": "Data-Link Services"
       },
       "mac": {
         "id": 9,
-        "loadaddr": "fffffffffbc6d268",
-        "size": 220128,
+        "loadaddr": "fffffffffbc78428",
+        "size": 241744,
         "description": "MAC Services"
       },
       "procfs": {
         "id": 10,
-        "loadaddr": "fffffffffbca2240",
-        "size": 133352,
+        "loadaddr": "fffffffffbcb25d0",
+        "size": 124520,
         "description": "filesystem for proc"
       },
       "TS": {
         "id": 12,
-        "loadaddr": "fffffffffbcc20a8",
-        "size": 16968,
+        "loadaddr": "fffffffffbcd0138",
+        "size": 14848,
         "description": "time sharing sched class"
       },
       "TS_DPTBL": {
         "id": 13,
-        "loadaddr": "fffffffffbcc5af0",
-        "size": 2544,
+        "loadaddr": "fffffffffbcd3338",
+        "size": 2312,
         "description": "Time sharing dispatch table"
       },
       "pci_autoconfig": {
         "id": 14,
-        "loadaddr": "fffffffffbcc5cb0",
-        "size": 44264,
+        "loadaddr": "fffffffffbcd3410",
+        "size": 41536,
         "description": "PCI BIOS interface"
       },
       "acpica": {
         "id": 15,
-        "loadaddr": "fffffffffbcd0840",
-        "size": 418512,
+        "loadaddr": "fffffffffbcdd4f8",
+        "size": 394576,
         "description": "ACPI interpreter"
       },
       "pcie": {
         "id": 16,
-        "loadaddr": "fffffffffbd35570",
-        "size": 303680,
+        "loadaddr": "fffffffffbd3c668",
+        "size": 310888,
         "description": "PCI Express Framework Module"
       },
       "busra": {
         "id": 17,
-        "loadaddr": "fffffffffbd7eee8",
-        "size": 10344,
+        "loadaddr": "fffffffffbd87770",
+        "size": 9704,
         "description": "Bus Resource Allocator (BUSRA)"
       },
       "iovcfg": {
         "id": 18,
-        "loadaddr": "fffffffffbd816f0",
-        "size": 13200,
+        "loadaddr": "fffffffffbd89cf8",
+        "size": 9616,
         "description": "IOV Configuration Module"
       },
-      "acpidev": {
+      "vnic": {
         "id": 19,
-        "loadaddr": "fffffffffbd84890",
-        "size": 76192,
+        "loadaddr": "fffffffffbd8bf68",
+        "size": 29704,
+        "description": "Virtual NIC"
+      },
+      "dld": {
+        "id": 20,
+        "loadaddr": "fffffffffbd93080",
+        "size": 34320,
+        "description": "Data-Link Driver"
+      },
+      "acpidev": {
+        "id": 21,
+        "loadaddr": "fffffffffbd9b090",
+        "size": 68176,
         "description": "ACPI device enumerator"
       },
       "isa": {
-        "id": 20,
-        "loadaddr": "fffffffffbd96790",
-        "size": 17472,
+        "id": 22,
+        "loadaddr": "fffffffffbdab040",
+        "size": 14848,
         "description": "isa nexus driver for 'ISA'"
       },
       "cpu.generic": {
-        "id": 21,
-        "loadaddr": "fffffffffbd9a698",
-        "size": 19088,
+        "id": 23,
+        "loadaddr": "fffffffffbdae4f8",
+        "size": 26864,
         "description": "Generic x86 CPU Module"
       },
       "uppc": {
-        "id": 23,
-        "loadaddr": "fffffffffbd9ff28",
-        "size": 14008,
+        "id": 25,
+        "loadaddr": "fffffffffbdb45a8",
+        "size": 11736,
         "description": "UniProcessor PC"
       },
       "pcplusmp": {
-        "id": 26,
-        "loadaddr": "fffffffffbdb8d60",
-        "size": 72368,
+        "id": 28,
+        "loadaddr": "fffffffffbdc93e8",
+        "size": 61080,
         "description": "pcplusmp v1.4 compatible"
       },
       "rootnex": {
-        "id": 27,
-        "loadaddr": "fffffffffbdca090",
-        "size": 19728,
+        "id": 30,
+        "loadaddr": "fffffffffbdd7af0",
+        "size": 6568,
         "description": "i86pc root nexus"
       },
       "options": {
-        "id": 28,
-        "loadaddr": "fffffffffbdcead0",
-        "size": 784,
+        "id": 31,
+        "loadaddr": "fffffffffbdd91f8",
+        "size": 480,
         "description": "options driver"
       },
       "pseudo": {
-        "id": 29,
-        "loadaddr": "fffffffffbdced20",
-        "size": 3256,
+        "id": 32,
+        "loadaddr": "fffffffffbdd9318",
+        "size": 2672,
         "description": "nexus driver for 'pseudo' 1.31"
       },
       "clone": {
-        "id": 30,
-        "loadaddr": "fffffffffbdcf7a0",
-        "size": 1880,
+        "id": 33,
+        "loadaddr": "fffffffffbdd9b48",
+        "size": 1592,
         "description": "Clone Pseudodriver 'clone'"
       },
       "scsi_vhci": {
-        "id": 31,
-        "loadaddr": "fffffffffbdcfcc0",
-        "size": 76384,
+        "id": 34,
+        "loadaddr": "fffffffffbdd9f48",
+        "size": 75208,
         "description": "SCSI VHCI Driver"
       },
       "scsi": {
-        "id": 32,
-        "loadaddr": "fffffffffbde24c8",
-        "size": 174328,
+        "id": 35,
+        "loadaddr": "fffffffffbdec298",
+        "size": 166328,
         "description": "SCSI Bus Utility Routines"
       },
       "scsi_vhci_f_asym_sun": {
-        "id": 33,
-        "loadaddr": "fffffffffbe08ea0",
-        "size": 3920,
+        "id": 36,
+        "loadaddr": "fffffffffbe10940",
+        "size": 3280,
         "description": "f_asym_sun"
       },
       "scsi_vhci_f_asym_lsi": {
-        "id": 34,
-        "loadaddr": "fffffffffbe09d20",
-        "size": 7872,
+        "id": 37,
+        "loadaddr": "fffffffffbe11540",
+        "size": 6968,
         "description": "f_asym_lsi"
       },
       "scsi_vhci_f_asym_emc": {
-        "id": 35,
-        "loadaddr": "fffffffffbe0b950",
-        "size": 4480,
+        "id": 38,
+        "loadaddr": "fffffffffbe12de0",
+        "size": 4248,
         "description": "f_asym_emc"
       },
       "scsi_vhci_f_sym_emc": {
-        "id": 36,
-        "loadaddr": "fffffffffbe0c9e8",
-        "size": 1072,
+        "id": 39,
+        "loadaddr": "fffffffffbe13d78",
+        "size": 832,
         "description": "f_sym_emc"
       },
       "scsi_vhci_f_sym_hds": {
-        "id": 37,
-        "loadaddr": "fffffffffbe0cd48",
-        "size": 2056,
+        "id": 40,
+        "loadaddr": "fffffffffbe13fe8",
+        "size": 1840,
         "description": "f_sym_hds"
       },
       "scsi_vhci_f_sym": {
-        "id": 38,
-        "loadaddr": "fffffffffbe0d488",
-        "size": 1840,
+        "id": 41,
+        "loadaddr": "fffffffffbe14648",
+        "size": 1552,
         "description": "f_sym"
       },
       "scsi_vhci_f_tpgs": {
-        "id": 39,
-        "loadaddr": "fffffffffbe0da68",
-        "size": 3264,
+        "id": 42,
+        "loadaddr": "fffffffffbe14ac8",
+        "size": 2696,
         "description": "f_tpgs"
       },
       "pci": {
-        "id": 43,
-        "loadaddr": "fffffffffbda33f8",
-        "size": 29392,
+        "id": 46,
+        "loadaddr": "fffffffffbdb7178",
+        "size": 26200,
         "description": "x86 Host to PCI nexus driver"
       },
       "pcihp": {
-        "id": 44,
-        "loadaddr": "fffffffffbdb2fc0",
-        "size": 22288,
+        "id": 47,
+        "loadaddr": "fffffffffbe15490",
+        "size": 20320,
         "description": "PCI nexus hotplug support"
       },
       "hpcsvc": {
-        "id": 45,
-        "loadaddr": "fffffffffbda9aa8",
-        "size": 5584,
+        "id": 48,
+        "loadaddr": "fffffffffbdbcba0",
+        "size": 4688,
         "description": "hot-plug controller services"
       },
       "kcf": {
-        "id": 46,
-        "loadaddr": "fffffffffbe0e668",
-        "size": 180128,
+        "id": 49,
+        "loadaddr": "fffffffffbe1a2e0",
+        "size": 174368,
         "description": "Kernel Crypto Framework"
       },
       "zfs": {
-        "id": 48,
-        "loadaddr": "fffffffff77fb000",
-        "size": 1017736,
+        "id": 51,
+        "loadaddr": "fffffffff77f9000",
+        "size": 988536,
         "description": "ZFS storage pool"
       },
       "swrand": {
-        "id": 49,
-        "loadaddr": "fffffffffbdab010",
-        "size": 11448,
-        "description": "Kernel Random number Provider"
+        "id": 52,
+        "loadaddr": "fffffffffbdbdd88",
+        "size": 34376,
+        "description": "Kernel Software-based Entropy P"
       },
       "sha1": {
-        "id": 50,
-        "loadaddr": "fffffffffbe376d0",
-        "size": 40528,
+        "id": 53,
+        "loadaddr": "fffffffffbe42fb8",
+        "size": 40152,
         "description": "SHA1 Kernel SW Provider"
       },
       "idmap": {
-        "id": 51,
-        "loadaddr": "fffffffff78e8000",
-        "size": 20232,
+        "id": 54,
+        "loadaddr": "fffffffff78de000",
+        "size": 17896,
         "description": "ID Mapping kernel module"
       },
       "doorfs": {
-        "id": 52,
-        "loadaddr": "fffffffff78ed000",
-        "size": 25496,
+        "id": 55,
+        "loadaddr": "fffffffff78e3000",
+        "size": 22080,
         "description": "32-bit door syscalls"
       },
       "rpcmod": {
-        "id": 53,
-        "loadaddr": "fffffffff78f4000",
-        "size": 152408,
+        "id": 56,
+        "loadaddr": "fffffffff78e9000",
+        "size": 135848,
         "description": "rpc interface str mod"
       },
       "tlimod": {
-        "id": 54,
-        "loadaddr": "fffffffffbe41210",
-        "size": 8816,
+        "id": 57,
+        "loadaddr": "fffffffffbe4c978",
+        "size": 7392,
         "description": "KTLI misc module"
       },
       "sha2": {
-        "id": 55,
-        "loadaddr": "fffffffff7913000",
-        "size": 27904,
+        "id": 58,
+        "loadaddr": "fffffffff7904000",
+        "size": 26504,
         "description": "SHA2 Kernel SW Provider"
       },
       "acpippm": {
-        "id": 56,
-        "loadaddr": "fffffffffbe43428",
-        "size": 3168,
+        "id": 59,
+        "loadaddr": "fffffffffbe4e600",
+        "size": 2560,
         "description": "ACPI ppm driver"
       },
       "ppm": {
-        "id": 57,
-        "loadaddr": "fffffffff791a000",
-        "size": 24272,
+        "id": 60,
+        "loadaddr": "fffffffff790a000",
+        "size": 21144,
         "description": "platform pm driver"
       },
-      "cmdk": {
-        "id": 58,
-        "loadaddr": "fffffffff7920000",
-        "size": 14232,
-        "description": "Common Direct Access Disk"
-      },
-      "dadk": {
-        "id": 59,
-        "loadaddr": "fffffffff7924000",
-        "size": 14800,
-        "description": "Direct Attached Disk"
-      },
-      "gda": {
-        "id": 60,
-        "loadaddr": "fffffffff7912378",
-        "size": 2920,
-        "description": "Generic Direct Attached Device "
-      },
-      "strategy": {
+      "ahci": {
         "id": 61,
-        "loadaddr": "fffffffff7928000",
-        "size": 8952,
-        "description": "Device Strategy Objects"
+        "loadaddr": "fffffffff790f000",
+        "size": 88928,
+        "description": "ahci driver"
       },
-      "cmlb": {
+      "sata": {
         "id": 62,
-        "loadaddr": "fffffffff792b000",
-        "size": 40808,
-        "description": "Common Labeling module"
-      },
-      "ata": {
-        "id": 63,
-        "loadaddr": "fffffffff7934000",
-        "size": 67232,
-        "description": "ATA AT-bus attachment disk cont"
-      },
-      "pci-ide": {
-        "id": 64,
-        "loadaddr": "fffffffff7944000",
-        "size": 5056,
-        "description": "pciide nexus driver for 'PCI-ID"
+        "loadaddr": "fffffffff7925000",
+        "size": 104248,
+        "description": "SATA Module"
       },
       "sd": {
-        "id": 67,
-        "loadaddr": "fffffffff796e000",
-        "size": 184672,
+        "id": 63,
+        "loadaddr": "fffffffff793f000",
+        "size": 177856,
         "description": "SCSI Disk Driver"
       },
+      "cmlb": {
+        "id": 64,
+        "loadaddr": "fffffffff7969000",
+        "size": 37784,
+        "description": "Common Labeling module"
+      },
       "SDC": {
-        "id": 86,
-        "loadaddr": "fffffffff7b7c000",
-        "size": 7544,
+        "id": 65,
+        "loadaddr": "fffffffffbdc5828",
+        "size": 6104,
         "description": "system duty cycle scheduling cl"
       },
       "ctfs": {
-        "id": 87,
-        "loadaddr": "fffffffff7b7e000",
-        "size": 16712,
+        "id": 66,
+        "loadaddr": "fffffffff7972000",
+        "size": 13392,
         "description": "contract filesystem"
       },
       "mntfs": {
-        "id": 88,
-        "loadaddr": "fffffffff7b82000",
-        "size": 17104,
+        "id": 67,
+        "loadaddr": "fffffffff7976000",
+        "size": 15048,
         "description": "mount information file system"
       },
       "tmpfs": {
-        "id": 89,
-        "loadaddr": "fffffffff7b87000",
-        "size": 95768,
+        "id": 68,
+        "loadaddr": "fffffffff797a000",
+        "size": 92816,
         "description": "filesystem for tmpfs"
       },
       "objfs": {
-        "id": 90,
-        "loadaddr": "fffffffff7b8f000",
-        "size": 9616,
+        "id": 69,
+        "loadaddr": "fffffffffbdc6b58",
+        "size": 7888,
         "description": "kernel object filesystem"
       },
       "sharefs": {
-        "id": 91,
-        "loadaddr": "fffffffff7b92000",
-        "size": 5688,
+        "id": 70,
+        "loadaddr": "fffffffff7981000",
+        "size": 4448,
         "description": "sharetab filesystem"
       },
       "acpinex": {
-        "id": 92,
-        "loadaddr": "fffffffff7b94000",
-        "size": 10672,
+        "id": 71,
+        "loadaddr": "fffffffff7983000",
+        "size": 9384,
         "description": "ACPI virtual bus driver"
       },
+      "cpudrv": {
+        "id": 72,
+        "loadaddr": "fffffffff81f1000",
+        "size": 9192,
+        "description": "CPU Driver"
+      },
       "strplumb": {
-        "id": 94,
-        "loadaddr": "fffffffff7b9a000",
-        "size": 6224,
+        "id": 73,
+        "loadaddr": "fffffffff7989000",
+        "size": 6320,
         "description": "STREAMS Plumbing Module"
       },
-      "dld": {
-        "id": 95,
-        "loadaddr": "fffffffff7b9c000",
-        "size": 37584,
-        "description": "Data-Link Driver"
-      },
       "ip": {
-        "id": 96,
-        "loadaddr": "fffffffff7ba5000",
-        "size": 1390288,
+        "id": 74,
+        "loadaddr": "fffffffff798b000",
+        "size": 1286784,
         "description": "IP STREAMS module 1.47"
       },
       "md5": {
-        "id": 97,
-        "loadaddr": "fffffffff7ce8000",
-        "size": 10784,
+        "id": 75,
+        "loadaddr": "fffffffff7ab4000",
+        "size": 9448,
         "description": "MD5 Kernel SW Provider"
       },
       "hook": {
-        "id": 98,
-        "loadaddr": "fffffffff7ceb000",
-        "size": 17280,
+        "id": 76,
+        "loadaddr": "fffffffff7ab7000",
+        "size": 14864,
         "description": "Hooks Interface v1.0"
       },
       "neti": {
-        "id": 99,
-        "loadaddr": "fffffffff7cf0000",
-        "size": 10112,
+        "id": 77,
+        "loadaddr": "fffffffff7abb000",
+        "size": 7352,
         "description": "netinfo module"
       },
       "ip6": {
-        "id": 100,
-        "loadaddr": "fffffffff79a7c70",
-        "size": 1456,
+        "id": 78,
+        "loadaddr": "fffffffff7abcc40",
+        "size": 1176,
         "description": "IP6 STREAMS driver"
       },
       "tcp": {
-        "id": 101,
-        "loadaddr": "fffffffff7a01b98",
-        "size": 1720,
+        "id": 79,
+        "loadaddr": "fffffffff7ab3b20",
+        "size": 1440,
         "description": "TCP socket module"
       },
       "tcp6": {
-        "id": 102,
-        "loadaddr": "fffffffff79f8ad0",
-        "size": 1464,
+        "id": 80,
+        "loadaddr": "fffffffff7ab3db0",
+        "size": 1184,
         "description": "TCP6 STREAMS driver"
       },
       "udp": {
-        "id": 103,
-        "loadaddr": "fffffffff7a0ba60",
-        "size": 1720,
+        "id": 81,
+        "loadaddr": "fffffffff78dda20",
+        "size": 1440,
         "description": "UDP socket module"
       },
       "udp6": {
-        "id": 104,
-        "loadaddr": "fffffffff791fa58",
-        "size": 1464,
+        "id": 82,
+        "loadaddr": "fffffffff78ddcb0",
+        "size": 1184,
         "description": "UDP6 STREAMS driver"
       },
       "icmp": {
-        "id": 105,
-        "loadaddr": "fffffffff7a5aa50",
-        "size": 1712,
+        "id": 83,
+        "loadaddr": "fffffffff7979a18",
+        "size": 1432,
         "description": "Rawip socket module"
       },
       "icmp6": {
-        "id": 106,
-        "loadaddr": "fffffffff7a4fa48",
-        "size": 1456,
+        "id": 84,
+        "loadaddr": "fffffffff7979ca0",
+        "size": 1176,
         "description": "ICMP6 STREAMS driver"
       },
       "arp": {
-        "id": 107,
-        "loadaddr": "fffffffff78e7978",
-        "size": 1544,
+        "id": 85,
+        "loadaddr": "fffffffff7aba9a0",
+        "size": 1264,
         "description": "ARP STREAMS module"
       },
       "timod": {
-        "id": 108,
-        "loadaddr": "fffffffff7cf3000",
-        "size": 19592,
+        "id": 86,
+        "loadaddr": "fffffffff7abd000",
+        "size": 18112,
         "description": "transport interface str mod"
       },
+      "consconfig": {
+        "id": 87,
+        "loadaddr": "fffffffff78ddee8",
+        "size": 376,
+        "description": "console configuration"
+      },
       "consconfig_dacf": {
-        "id": 110,
-        "loadaddr": "fffffffff7cf8000",
-        "size": 23784,
+        "id": 88,
+        "loadaddr": "fffffffff7ac1000",
+        "size": 21032,
         "description": "Consconfig DACF"
       },
       "usbser": {
-        "id": 111,
-        "loadaddr": "fffffffff7cfd000",
-        "size": 21704,
+        "id": 89,
+        "loadaddr": "fffffffff7ac5000",
+        "size": 17704,
         "description": "USB generic serial module"
       },
       "usba": {
-        "id": 112,
-        "loadaddr": "fffffffff7d03000",
-        "size": 253024,
+        "id": 90,
+        "loadaddr": "fffffffff7aca000",
+        "size": 234576,
         "description": "USBA: USB Architecture 2.0 1.66"
       },
       "i8042": {
-        "id": 113,
-        "loadaddr": "fffffffff7d40000",
-        "size": 7096,
+        "id": 91,
+        "loadaddr": "fffffffff7b02000",
+        "size": 6080,
         "description": "i8042 nexus driver"
       },
       "vgatext": {
-        "id": 114,
-        "loadaddr": "fffffffff7d42000",
-        "size": 11392,
+        "id": 92,
+        "loadaddr": "fffffffff79852d0",
+        "size": 10216,
         "description": "VGA text driver"
       },
       "agpmaster": {
-        "id": 115,
-        "loadaddr": "fffffffff7d44000",
-        "size": 7104,
+        "id": 93,
+        "loadaddr": "fffffffff7b04000",
+        "size": 7240,
         "description": "AGP master interfaces"
       },
       "gfx_private": {
-        "id": 116,
-        "loadaddr": "fffffffff7d46000",
-        "size": 33744,
+        "id": 94,
+        "loadaddr": "fffffffff7b06000",
+        "size": 30104,
         "description": "gfx private interfaces"
       },
       "conskbd": {
-        "id": 117,
-        "loadaddr": "fffffffff7d4d000",
-        "size": 11672,
+        "id": 95,
+        "loadaddr": "fffffffff7b0c000",
+        "size": 9928,
         "description": "conskbd multiplexer driver"
       },
       "kbtrans": {
-        "id": 118,
-        "loadaddr": "fffffffff7d50000",
-        "size": 19368,
+        "id": 96,
+        "loadaddr": "fffffffff7b0f000",
+        "size": 16752,
         "description": "kbtrans (key translation)"
       },
       "consms": {
-        "id": 119,
-        "loadaddr": "fffffffff7d54000",
-        "size": 7448,
+        "id": 97,
+        "loadaddr": "fffffffff7b12000",
+        "size": 6112,
         "description": "Mouse Driver for Sun 'consms' 5"
       },
       "wc": {
-        "id": 120,
-        "loadaddr": "fffffffff7d56000",
-        "size": 16808,
+        "id": 98,
+        "loadaddr": "fffffffff7b14000",
+        "size": 14008,
         "description": "Workstation multiplexer Driver "
       },
       "tem": {
-        "id": 121,
-        "loadaddr": "fffffffff7d5a000",
-        "size": 24392,
+        "id": 99,
+        "loadaddr": "fffffffff7b18000",
+        "size": 20160,
         "description": "ANSI Terminal Emulator"
       },
       "iwscn": {
-        "id": 122,
-        "loadaddr": "fffffffff7999238",
-        "size": 3872,
+        "id": 100,
+        "loadaddr": "fffffffff78e2560",
+        "size": 3064,
         "description": "Workstation Redirection driver"
       },
+      "ohci": {
+        "id": 103,
+        "loadaddr": "fffffffff7b41000",
+        "size": 68048,
+        "description": "USB OpenHCI Driver"
+      },
       "kb8042": {
-        "id": 126,
-        "loadaddr": "fffffffff7d9c000",
-        "size": 13544,
+        "id": 104,
+        "loadaddr": "fffffffff7b52000",
+        "size": 12048,
         "description": "PS/2 keyboard driver"
       },
       "mouse8042": {
-        "id": 127,
-        "loadaddr": "fffffffff7d9f000",
-        "size": 4856,
+        "id": 105,
+        "loadaddr": "fffffffffbdc8640",
+        "size": 4072,
         "description": "PS/2 Mouse"
       },
       "vuid3ps2": {
-        "id": 128,
-        "loadaddr": "fffffffff7da1000",
-        "size": 8976,
+        "id": 106,
+        "loadaddr": "fffffffff7b54000",
+        "size": 7896,
         "description": "mouse events to vuid events"
       },
+      "ibdm": {
+        "id": 108,
+        "loadaddr": "fffffffff7b63000",
+        "size": 44112,
+        "description": "InfiniBand Device Manager"
+      },
+      "ibtl": {
+        "id": 109,
+        "loadaddr": "fffffffff7b6e000",
+        "size": 125688,
+        "description": "IB Transport Layer"
+      },
+      "ibmf": {
+        "id": 110,
+        "loadaddr": "fffffffff7b8c000",
+        "size": 118400,
+        "description": "IB Agent Interfaces 2.0"
+      },
       "acpi_drv": {
-        "id": 133,
-        "loadaddr": "fffffffff7da4000",
-        "size": 19536,
+        "id": 111,
+        "loadaddr": "fffffffff7b56000",
+        "size": 16792,
         "description": "ACPI driver"
       },
       "elfexec": {
-        "id": 140,
-        "loadaddr": "fffffffff7e02000",
-        "size": 44496,
+        "id": 118,
+        "loadaddr": "fffffffff7bdb000",
+        "size": 44848,
         "description": "32-bit exec module for elf"
       },
+      "hcad": {
+        "id": 121,
+        "loadaddr": "fffffffff7bbe000",
+        "size": 12600,
+        "description": "HCA Driver"
+      },
       "smbios": {
-        "id": 149,
-        "loadaddr": "fffffffff7cf2708",
-        "size": 2640,
+        "id": 127,
+        "loadaddr": "fffffffff7bda8f8",
+        "size": 2104,
         "description": "System Management BIOS driver"
       },
       "kssl": {
-        "id": 153,
-        "loadaddr": "fffffffff7e4e000",
-        "size": 11880,
+        "id": 131,
+        "loadaddr": "fffffffff7bc1000",
+        "size": 10768,
         "description": "Kernel SSL Interface"
       },
-      "fctl": {
-        "id": 160,
-        "loadaddr": "fffffffff7e7a000",
-        "size": 42368,
-        "description": "SunFC Transport v20090729-1.70"
+      "zvmisc": {
+        "id": 139,
+        "loadaddr": "fffffffff7c69bf0",
+        "size": 1152,
+        "description": "kernel zone common driver code"
       },
       "sad": {
-        "id": 162,
-        "loadaddr": "fffffffff7e86000",
-        "size": 4936,
+        "id": 142,
+        "loadaddr": "fffffffff7bb2060",
+        "size": 4312,
         "description": "STREAMS Administrative Driver '"
       },
       "ldterm": {
-        "id": 163,
-        "loadaddr": "fffffffff7f98000",
-        "size": 60952,
+        "id": 143,
+        "loadaddr": "fffffffff7ca8000",
+        "size": 58424,
         "description": "terminal line discipline"
       },
       "ttcompat": {
-        "id": 164,
-        "loadaddr": "fffffffff7e88000",
-        "size": 8240,
+        "id": 144,
+        "loadaddr": "fffffffff7bc8000",
+        "size": 7552,
         "description": "alt ioctl calls"
       },
       "ptsl": {
-        "id": 166,
-        "loadaddr": "fffffffff7e8a000",
-        "size": 5864,
+        "id": 146,
+        "loadaddr": "fffffffff7cbd000",
+        "size": 5240,
         "description": "tty pseudo driver slave 'ptsl'"
       },
       "ptc": {
-        "id": 167,
-        "loadaddr": "fffffffff7e8c000",
-        "size": 7672,
+        "id": 147,
+        "loadaddr": "fffffffff7cbf000",
+        "size": 6912,
         "description": "tty pseudo driver control 'ptc'"
       },
       "ipsecesp": {
-        "id": 174,
-        "loadaddr": "fffffffff7fcd000",
-        "size": 31768,
+        "id": 154,
+        "loadaddr": "fffffffff7cdb000",
+        "size": 29264,
         "description": "IPsec ESP STREAMS module"
       },
       "ipsecah": {
-        "id": 175,
-        "loadaddr": "fffffffff7fd5000",
-        "size": 84520,
+        "id": 155,
+        "loadaddr": "fffffffff7ce2000",
+        "size": 79488,
         "description": "IPsec AH STREAMS module"
       },
       "sysmsg": {
-        "id": 177,
-        "loadaddr": "fffffffff7e8e000",
-        "size": 6384,
+        "id": 158,
+        "loadaddr": "fffffffff7b62000",
+        "size": 5608,
         "description": "System message redirection (fan"
       },
       "cn": {
-        "id": 178,
-        "loadaddr": "fffffffff7b93570",
-        "size": 3000,
+        "id": 159,
+        "loadaddr": "fffffffff7b5c7b0",
+        "size": 2392,
         "description": "Console redirection driver"
       },
       "mm": {
-        "id": 179,
-        "loadaddr": "fffffffff7ff3000",
-        "size": 7088,
+        "id": 160,
+        "loadaddr": "fffffffff7cfe000",
+        "size": 6376,
         "description": "memory driver"
       },
       "pipe": {
-        "id": 180,
-        "loadaddr": "fffffffff7e21d18",
-        "size": 912,
+        "id": 161,
+        "loadaddr": "fffffffff7b1cdd8",
+        "size": 720,
         "description": "32-bit pipe(2) syscall"
       },
+      "hid": {
+        "id": 162,
+        "loadaddr": "fffffffff7d00000",
+        "size": 22544,
+        "description": "USB HID Client Driver"
+      },
+      "hidparser": {
+        "id": 163,
+        "loadaddr": "fffffffff7d06000",
+        "size": 13832,
+        "description": "HID Parser"
+      },
+      "usbms": {
+        "id": 164,
+        "loadaddr": "fffffffff7d0a000",
+        "size": 10000,
+        "description": "USB mouse streams"
+      },
       "namefs": {
-        "id": 181,
-        "loadaddr": "fffffffff7ff5000",
-        "size": 9000,
+        "id": 165,
+        "loadaddr": "fffffffff7d0d000",
+        "size": 7320,
         "description": "filesystem for namefs"
       },
       "portfs": {
-        "id": 182,
-        "loadaddr": "fffffffff7ff8000",
-        "size": 27832,
+        "id": 166,
+        "loadaddr": "fffffffff7d0f000",
+        "size": 27336,
         "description": "32-bit event ports syscalls"
       },
       "intpexec": {
-        "id": 183,
-        "loadaddr": "fffffffff7ff4a20",
-        "size": 1600,
+        "id": 167,
+        "loadaddr": "fffffffff7ee7a98",
+        "size": 1352,
         "description": "exec mod for interp"
       },
       "sysevent": {
-        "id": 184,
-        "loadaddr": "fffffffff7fff000",
-        "size": 5664,
+        "id": 168,
+        "loadaddr": "fffffffff7d16000",
+        "size": 4608,
         "description": "sysevent driver"
       },
+      "log": {
+        "id": 169,
+        "loadaddr": "fffffffff7cc48c0",
+        "size": 2416,
+        "description": "streams log driver"
+      },
+      "rds": {
+        "id": 170,
+        "loadaddr": "fffffffff7d18000",
+        "size": 11368,
+        "description": "RDS STREAMS driver"
+      },
       "sockfs": {
-        "id": 185,
-        "loadaddr": "fffffffff8001000",
-        "size": 201832,
+        "id": 171,
+        "loadaddr": "fffffffff7d1b000",
+        "size": 178240,
         "description": "filesystem for sockfs"
       },
       "tl": {
-        "id": 186,
-        "loadaddr": "fffffffff8031000",
-        "size": 29776,
+        "id": 172,
+        "loadaddr": "fffffffff7d45000",
+        "size": 28016,
         "description": "TPI Local Transport (tl)"
       },
       "keysock": {
-        "id": 187,
-        "loadaddr": "fffffffff8038000",
-        "size": 19352,
+        "id": 173,
+        "loadaddr": "fffffffff7d4c000",
+        "size": 17736,
         "description": "PF_KEY socket STREAMS module"
       },
       "spdsock": {
-        "id": 188,
-        "loadaddr": "fffffffff803d000",
-        "size": 28272,
+        "id": 174,
+        "loadaddr": "fffffffff7d50000",
+        "size": 24728,
         "description": "PF_POLICY socket STREAMS driver"
       },
-      "rds": {
-        "id": 189,
-        "loadaddr": "fffffffff8044000",
-        "size": 13408,
-        "description": "RDS STREAMS driver"
-      },
-      "log": {
-        "id": 190,
-        "loadaddr": "fffffffff7b9b710",
-        "size": 2832,
-        "description": "streams log driver"
-      },
-      "softmac": {
-        "id": 191,
-        "loadaddr": "fffffffff8063000",
-        "size": 39968,
-        "description": "softmac driver"
-      },
       "lofs": {
-        "id": 192,
-        "loadaddr": "fffffffff7e90000",
-        "size": 21136,
+        "id": 175,
+        "loadaddr": "fffffffff7c5d000",
+        "size": 17616,
         "description": "filesystem for lofs"
       },
-      "cryptoadm": {
-        "id": 193,
-        "loadaddr": "fffffffff7e96000",
-        "size": 6656,
-        "description": "Cryptographic Administrative In"
+      "kstat": {
+        "id": 176,
+        "loadaddr": "fffffffff7c61340",
+        "size": 4392,
+        "description": "kernel statistics driver"
+      },
+      "fdfs": {
+        "id": 177,
+        "loadaddr": "fffffffff7d17090",
+        "size": 4192,
+        "description": "filesystem for fd"
       },
       "cubic": {
-        "id": 194,
-        "loadaddr": "fffffffff7fd43e0",
-        "size": 4416,
+        "id": 178,
+        "loadaddr": "fffffffff79806e8",
+        "size": 3688,
         "description": "cubic congestion control module"
       },
       "highspeed": {
-        "id": 195,
-        "loadaddr": "fffffffff7fbda18",
-        "size": 2160,
+        "id": 179,
+        "loadaddr": "fffffffff7b11c60",
+        "size": 1616,
         "description": "highspeed congestion control mo"
       },
       "vegas": {
-        "id": 196,
-        "loadaddr": "fffffffff7b7d8d0",
-        "size": 2376,
+        "id": 180,
+        "loadaddr": "fffffffff7ce1a18",
+        "size": 1792,
         "description": "vegas congestion control module"
       },
       "rts": {
-        "id": 197,
-        "loadaddr": "fffffffff7e0cc78",
-        "size": 1568,
+        "id": 181,
+        "loadaddr": "fffffffff7ba8d50",
+        "size": 1288,
         "description": "PF_ROUTE socket module"
       },
-      "random": {
-        "id": 199,
-        "loadaddr": "fffffffff8043968",
-        "size": 2064,
-        "description": "random number device"
+      "softmac": {
+        "id": 182,
+        "loadaddr": "fffffffff7d63000",
+        "size": 34864,
+        "description": "softmac driver"
       },
-      "fdfs": {
-        "id": 200,
-        "loadaddr": "fffffffff7e98000",
-        "size": 4992,
-        "description": "filesystem for fd"
+      "ibcm": {
+        "id": 184,
+        "loadaddr": "fffffffff7d84000",
+        "size": 183984,
+        "description": "IB Communication Manager"
       },
-      "e1000g": {
-        "id": 201,
-        "loadaddr": "fffffffff80b4000",
-        "size": 223984,
-        "description": "Intel PRO/1000 Ethernet"
-      },
-      "mac_ether": {
-        "id": 202,
-        "loadaddr": "fffffffff7e5b348",
-        "size": 6792,
-        "description": "Ethernet MAC plugin"
-      },
-      "vboxguest": {
-        "id": 204,
-        "loadaddr": "fffffffff80eb000",
-        "size": 151768,
-        "description": "VirtualBox GstDrv 4.3.2r90405"
-      },
-      "ctf": {
-        "id": 205,
-        "loadaddr": "fffffffff806d000",
-        "size": 40384,
-        "description": "Compact C Type Format routines"
-      },
-      "devinfo": {
-        "id": 206,
-        "loadaddr": "fffffffff79f9000",
-        "size": 25848,
-        "description": "DEVINFO Driver"
-      },
-      "xsvc": {
-        "id": 207,
-        "loadaddr": "fffffffff7e9a000",
-        "size": 6384,
-        "description": "xsvc driver"
+      "cryptoadm": {
+        "id": 185,
+        "loadaddr": "fffffffff7c62320",
+        "size": 5512,
+        "description": "Cryptographic Administrative In"
       },
       "FX": {
-        "id": 208,
-        "loadaddr": "fffffffff807e000",
-        "size": 13256,
+        "id": 186,
+        "loadaddr": "fffffffff7c63760",
+        "size": 11248,
         "description": "Fixed priority sched class"
       },
       "FX_DPTBL": {
-        "id": 209,
-        "loadaddr": "fffffffff8062e98",
-        "size": 936,
+        "id": 187,
+        "loadaddr": "fffffffff7975f50",
+        "size": 744,
         "description": "Fixed priority dispatch table"
       },
-      "sy": {
-        "id": 210,
-        "loadaddr": "fffffffff7d4c910",
-        "size": 2064,
-        "description": "Indirect driver for tty 'sy'"
-      },
-      "pool": {
-        "id": 212,
-        "loadaddr": "fffffffff7e9c000",
-        "size": 5296,
-        "description": "pool driver"
-      },
-      "openeepr": {
-        "id": 213,
-        "loadaddr": "fffffffff8085000",
-        "size": 7904,
-        "description": "OPENPROM/NVRAM Driver"
-      },
-      "iscsi": {
-        "id": 214,
-        "loadaddr": "fffffffff810d000",
-        "size": 227760,
-        "description": "iSCSI Initiator v-1.55"
-      },
-      "ksocket": {
-        "id": 215,
-        "loadaddr": "fffffffff8087000",
-        "size": 6984,
-        "description": "kernel socket module"
-      },
-      "idm": {
-        "id": 216,
-        "loadaddr": "fffffffff8089000",
-        "size": 80536,
-        "description": "iSCSI Data Mover"
-      },
-      "kstat": {
-        "id": 217,
-        "loadaddr": "fffffffff809d000",
-        "size": 4672,
-        "description": "kernel statistics driver"
+      "intelrd": {
+        "id": 188,
+        "loadaddr": "fffffffff7b0ba18",
+        "size": 9816,
+        "description": "Intel Entropy Provider"
       },
       "aes": {
-        "id": 218,
-        "loadaddr": "fffffffff8144000",
-        "size": 91760,
+        "id": 189,
+        "loadaddr": "fffffffff7db1000",
+        "size": 89496,
         "description": "AES Kernel SW Provider"
       },
       "des": {
-        "id": 219,
-        "loadaddr": "fffffffff809f000",
-        "size": 47544,
+        "id": 190,
+        "loadaddr": "fffffffff7dc7000",
+        "size": 45048,
         "description": "DES Kernel SW Provider"
       },
       "blowfish": {
-        "id": 220,
-        "loadaddr": "fffffffff80aa000",
-        "size": 12504,
+        "id": 191,
+        "loadaddr": "fffffffff7c65b80",
+        "size": 11216,
         "description": "Blowfish Kernel SW Provider"
       },
-      "vboxms": {
+      "camellia": {
+        "id": 192,
+        "loadaddr": "fffffffff7dd1000",
+        "size": 26920,
+        "description": "Camellia Kernel SW Provider"
+      },
+      "random": {
+        "id": 193,
+        "loadaddr": "fffffffff7beb9f8",
+        "size": 1544,
+        "description": "random number device"
+      },
+      "devinfo": {
+        "id": 194,
+        "loadaddr": "fffffffffbdbf1a0",
+        "size": 25712,
+        "description": "DEVINFO Driver"
+      },
+      "fcoe": {
+        "id": 195,
+        "loadaddr": "fffffffff7dfa000",
+        "size": 35880,
+        "description": "FCoE Transport v20140219-1.10"
+      },
+      "iscsi": {
+        "id": 196,
+        "loadaddr": "fffffffff7e03000",
+        "size": 206792,
+        "description": "iSCSI Initiator v-1.66"
+      },
+      "ksocket": {
+        "id": 197,
+        "loadaddr": "fffffffff7c68500",
+        "size": 5752,
+        "description": "kernel socket module"
+      },
+      "idm": {
+        "id": 198,
+        "loadaddr": "fffffffff7e35000",
+        "size": 70624,
+        "description": "iSCSI Data Mover"
+      },
+      "vga_arbiter": {
+        "id": 199,
+        "loadaddr": "fffffffff7cc1000",
+        "size": 11592,
+        "description": "vga_arbiter driver"
+      },
+      "xsvc": {
+        "id": 200,
+        "loadaddr": "fffffffff7e49000",
+        "size": 5392,
+        "description": "xsvc driver"
+      },
+      "aggr": {
+        "id": 201,
+        "loadaddr": "fffffffff8218000",
+        "size": 43784,
+        "description": "Link Aggregation MAC"
+      },
+      "e1000g": {
+        "id": 202,
+        "loadaddr": "fffffffff7e56000",
+        "size": 202704,
+        "description": "Intel PRO/1000 Ethernet"
+      },
+      "biosdrv": {
+        "id": 203,
+        "loadaddr": "fffffffff7d82610",
+        "size": 6000,
+        "description": "biosdrv 1.0 Generic Driver"
+      },
+      "mac_ether": {
+        "id": 204,
+        "loadaddr": "fffffffff7d0c580",
+        "size": 6344,
+        "description": "Ethernet MAC plugin"
+      },
+      "bl": {
+        "id": 205,
+        "loadaddr": "fffffffff7d62bf0",
+        "size": 1336,
+        "description": "blacklist driver"
+      },
+      "bridge": {
+        "id": 208,
+        "loadaddr": "fffffffff7be5dc8",
+        "size": 23024,
+        "description": "bridging driver"
+      },
+      "cap": {
+        "id": 209,
+        "loadaddr": "fffffffff7f19000",
+        "size": 9280,
+        "description": "packet capture interface"
+      },
+      "cpuid": {
+        "id": 211,
+        "loadaddr": "fffffffff7d55b90",
+        "size": 1464,
+        "description": "cpuid driver"
+      },
+      "crypto": {
+        "id": 212,
+        "loadaddr": "fffffffff7d6b000",
+        "size": 90480,
+        "description": "Cryptographic Library Interface"
+      },
+      "defdump": {
+        "id": 214,
+        "loadaddr": "fffffffff81f3308",
+        "size": 5256,
+        "description": "deferred dump processing"
+      },
+      "dlpistub": {
+        "id": 215,
+        "loadaddr": "fffffffff7dc6850",
+        "size": 2552,
+        "description": "DLPI stub driver"
+      },
+      "eib": {
+        "id": 216,
+        "loadaddr": "fffffffff7bec000",
+        "size": 132792,
+        "description": "Ethernet Over InfiniBand"
+      },
+      "fasttrap": {
+        "id": 217,
+        "loadaddr": "fffffffff7ed2000",
+        "size": 20096,
+        "description": "Fasttrap Tracing"
+      },
+      "fbt": {
+        "id": 218,
+        "loadaddr": "fffffffff81f7270",
+        "size": 3856,
+        "description": "Function Boundary Tracing"
+      },
+      "ctf": {
+        "id": 219,
+        "loadaddr": "fffffffff7ba9000",
+        "size": 35208,
+        "description": "Compact C Type Format routines"
+      },
+      "fcip": {
+        "id": 220,
+        "loadaddr": "fffffffff7ee0000",
+        "size": 32312,
+        "description": "SunFC FCIP v1.64"
+      },
+      "fctl": {
         "id": 221,
-        "loadaddr": "fffffffff80ad000",
-        "size": 15272,
-        "description": "VBoxMouseIntegr 4.3.2r90405"
+        "loadaddr": "fffffffff7ee8000",
+        "size": 37384,
+        "description": "SunFC Transport v20150515-1.73"
+      },
+      "fcp": {
+        "id": 222,
+        "loadaddr": "fffffffff81ac000",
+        "size": 96360,
+        "description": "SunFC FCP v20150618-1.197"
+      },
+      "fcsm": {
+        "id": 223,
+        "loadaddr": "fffffffff8223000",
+        "size": 19288,
+        "description": "SunFC FCSM v20120510-1.30"
+      },
+      "fm": {
+        "id": 224,
+        "loadaddr": "fffffffff7b5a000",
+        "size": 5072,
+        "description": "fault management driver"
+      },
+      "ipnet": {
+        "id": 226,
+        "loadaddr": "fffffffff8228000",
+        "size": 18680,
+        "description": "STREAMS ipnet driver"
+      },
+      "ippctl": {
+        "id": 227,
+        "loadaddr": "fffffffff7f1b198",
+        "size": 6360,
+        "description": "IP Policy Configuration Driver"
+      },
+      "iptun": {
+        "id": 228,
+        "loadaddr": "fffffffff7ed7000",
+        "size": 19296,
+        "description": "IP tunneling driver"
+      },
+      "kmdb": {
+        "id": 229,
+        "loadaddr": "fffffffff7b05bb0",
+        "size": 1432,
+        "description": "kmdb driver"
+      },
+      "kmdbmod": {
+        "id": 230,
+        "loadaddr": "fffffffff8232000",
+        "size": 936760,
+        "description": "kmdb 1.0 Proto"
+      },
+      "llc1": {
+        "id": 231,
+        "loadaddr": "fffffffff7edc000",
+        "size": 16488,
+        "description": "LLC Class 1 Driver"
+      },
+      "lockstat": {
+        "id": 232,
+        "loadaddr": "fffffffff7eb09a8",
+        "size": 2440,
+        "description": "Lock Statistics"
+      },
+      "lofi": {
+        "id": 233,
+        "loadaddr": "fffffffff81c4000",
+        "size": 49080,
+        "description": "loopback file driver"
+      },
+      "openeepr": {
+        "id": 235,
+        "loadaddr": "fffffffff800c000",
+        "size": 7032,
+        "description": "OPENPROM/NVRAM Driver"
+      },
+      "physmem": {
+        "id": 236,
+        "loadaddr": "fffffffff822d000",
+        "size": 5304,
+        "description": "physmem driver"
+      },
+      "poll": {
+        "id": 237,
+        "loadaddr": "fffffffff7d80fe8",
+        "size": 6024,
+        "description": "/dev/poll driver"
       },
       "power": {
-        "id": 223,
-        "loadaddr": "fffffffff80b1000",
-        "size": 6120,
+        "id": 238,
+        "loadaddr": "fffffffff8012000",
+        "size": 5328,
         "description": "power button driver"
       },
+      "profile": {
+        "id": 239,
+        "loadaddr": "fffffffff7986000",
+        "size": 4872,
+        "description": "Profile Interrupt Tracing"
+      },
+      "ramdisk": {
+        "id": 240,
+        "loadaddr": "fffffffff7e46000",
+        "size": 8016,
+        "description": "ramdisk driver"
+      },
+      "sdpib": {
+        "id": 242,
+        "loadaddr": "fffffffff7c6a000",
+        "size": 112352,
+        "description": "SDP IB STREAMS driver"
+      },
+      "sdt": {
+        "id": 243,
+        "loadaddr": "fffffffff800e000",
+        "size": 60016,
+        "description": "Statically Defined Tracing"
+      },
+      "simnet": {
+        "id": 244,
+        "loadaddr": "fffffffff7b5d000",
+        "size": 8784,
+        "description": "Simulated Network Driver"
+      },
+      "smbsrv": {
+        "id": 245,
+        "loadaddr": "fffffffff7f1e000",
+        "size": 7819120,
+        "description": "CIFS Server Protocol"
+      },
+      "klmmod": {
+        "id": 246,
+        "loadaddr": "fffffffff8097000",
+        "size": 38216,
+        "description": "lock mgr common module"
+      },
       "nfs": {
-        "id": 225,
-        "loadaddr": "fffffffff816b000",
-        "size": 646432,
+        "id": 247,
+        "loadaddr": "fffffffff80a1000",
+        "size": 588592,
         "description": "network filesystem version 4"
       },
       "rpcsec": {
-        "id": 226,
-        "loadaddr": "fffffffff8207000",
-        "size": 25192,
+        "id": 248,
+        "loadaddr": "fffffffff812f000",
+        "size": 20832,
         "description": "kernel RPC security module."
       },
-      "autofs": {
-        "id": 227,
-        "loadaddr": "fffffffff820e000",
-        "size": 35944,
-        "description": "AUTOFS syscall (32-bit)"
+      "sol_ucma": {
+        "id": 249,
+        "loadaddr": "fffffffff8134000",
+        "size": 25672,
+        "description": "Solaris User RDMACM driver"
       },
-      "pset": {
-        "id": 229,
-        "loadaddr": "fffffffff8223000",
-        "size": 7080,
-        "description": "32-bit pset(2) syscall"
-      },
-      "c2audit": {
-        "id": 230,
-        "loadaddr": "fffffffff8225000",
-        "size": 83960,
-        "description": "Solaris Auditing (C2)"
-      },
-      "fm": {
-        "id": 231,
-        "loadaddr": "fffffffffbdac8c8",
-        "size": 5984,
-        "description": "fault management driver"
-      },
-      "cpuid": {
-        "id": 232,
-        "loadaddr": "fffffffff7cfc9d8",
-        "size": 1904,
-        "description": "cpuid driver"
-      },
-      "fcoe": {
-        "id": 237,
-        "loadaddr": "fffffffff8287000",
-        "size": 34800,
-        "description": "FCoE Transport v20120513-1.05"
-      },
-      "sppp": {
-        "id": 238,
-        "loadaddr": "fffffffff8290000",
-        "size": 21384,
-        "description": "PPP 4.0 mux"
-      },
-      "pit_beep": {
-        "id": 240,
-        "loadaddr": "fffffffff7e50b50",
-        "size": 1480,
-        "description": "Intel Pit_beep Driver"
-      },
-      "cpc": {
-        "id": 246,
-        "loadaddr": "fffffffff82d6000",
-        "size": 6600,
-        "description": "32-bit cpc sampling system call"
-      },
-      "crypto": {
-        "id": 247,
-        "loadaddr": "fffffffff7946000",
-        "size": 94984,
-        "description": "Cryptographic Library Interface"
-      },
-      "fasttrap": {
+      "sol_ofs": {
         "id": 250,
-        "loadaddr": "fffffffff82f2000",
-        "size": 22584,
-        "description": "Fasttrap Tracing"
+        "loadaddr": "fffffffff813b000",
+        "size": 130776,
+        "description": "Solaris OFS Misc module"
       },
-      "fcip": {
+      "srn": {
+        "id": 251,
+        "loadaddr": "fffffffff7d09548",
+        "size": 3160,
+        "description": "srn driver"
+      },
+      "sy": {
         "id": 252,
-        "loadaddr": "fffffffff82fa000",
-        "size": 36624,
-        "description": "SunFC FCIP v1.61"
+        "loadaddr": "fffffffff7e45ae0",
+        "size": 1536,
+        "description": "Indirect driver for tty 'sy'"
+      },
+      "systrace": {
+        "id": 253,
+        "loadaddr": "fffffffff7cc09a8",
+        "size": 1944,
+        "description": "System Call Tracing"
+      },
+      "ucode": {
+        "id": 254,
+        "loadaddr": "fffffffff7edb848",
+        "size": 2264,
+        "description": "ucode driver"
+      },
+      "uvfs": {
+        "id": 256,
+        "loadaddr": "fffffffff815a000",
+        "size": 39816,
+        "description": "User virtual file system driver"
+      },
+      "vxlan": {
+        "id": 257,
+        "loadaddr": "fffffffff7bb3000",
+        "size": 25144,
+        "description": "VXLAN tunneling driver"
+      },
+      "bpf": {
+        "id": 259,
+        "loadaddr": "fffffffff81e2000",
+        "size": 18520,
+        "description": "Berkely Packet Filter"
+      },
+      "dump": {
+        "id": 260,
+        "loadaddr": "fffffffff7beb2c0",
+        "size": 2088,
+        "description": "crash dump driver"
+      },
+      "fssnap": {
+        "id": 261,
+        "loadaddr": "fffffffff7bb9000",
+        "size": 12416,
+        "description": "snapshot driver"
       },
       "fssnap_if": {
-        "id": 279,
-        "loadaddr": "fffffffff7e8dca0",
-        "size": 976,
+        "id": 262,
+        "loadaddr": "fffffffff7d83e28",
+        "size": 584,
         "description": "File System Snapshot Interface"
       },
       "ufs": {
-        "id": 280,
-        "loadaddr": "fffffffff8446000",
-        "size": 262960,
+        "id": 263,
+        "loadaddr": "fffffffff8172000",
+        "size": 239968,
         "description": "filesystem for ufs"
       },
-      "ipf": {
-        "id": 281,
-        "loadaddr": "fffffffff8485000",
-        "size": 236208,
-        "description": "IP Filter: v4.1.9"
-      },
       "ksyms": {
-        "id": 282,
-        "loadaddr": "fffffffff7d02208",
-        "size": 3912,
+        "id": 265,
+        "loadaddr": "fffffffff78e84f8",
+        "size": 3128,
         "description": "kernel symbols driver"
       },
       "logindmux": {
-        "id": 283,
-        "loadaddr": "fffffffff84be000",
-        "size": 7984,
+        "id": 266,
+        "loadaddr": "fffffffff81e0000",
+        "size": 6896,
         "description": "logindmux driver"
       },
+      "nsmb": {
+        "id": 267,
+        "loadaddr": "fffffffff7c41000",
+        "size": 53944,
+        "description": "SMBFS network driver"
+      },
+      "md4": {
+        "id": 268,
+        "loadaddr": "fffffffff7bbc000",
+        "size": 5136,
+        "description": "MD4 Kernel SW Provider"
+      },
+      "pm": {
+        "id": 269,
+        "loadaddr": "fffffffff7c4e000",
+        "size": 23160,
+        "description": "power management driver"
+      },
+      "pool": {
+        "id": 270,
+        "loadaddr": "fffffffff81f6000",
+        "size": 5056,
+        "description": "pool driver"
+      },
       "ptm": {
-        "id": 284,
-        "loadaddr": "fffffffff816a2a8",
-        "size": 3976,
+        "id": 271,
+        "loadaddr": "fffffffff81f5458",
+        "size": 3544,
         "description": "Master streams driver 'ptm'"
       },
       "pts": {
-        "id": 285,
-        "loadaddr": "fffffffff7ff7280",
-        "size": 4008,
+        "id": 272,
+        "loadaddr": "fffffffff7f1d490",
+        "size": 3488,
         "description": "Slave Stream Pseudo Terminal dr"
       },
+      "sppp": {
+        "id": 273,
+        "loadaddr": "fffffffff81f8000",
+        "size": 18840,
+        "description": "PPP 4.0 mux"
+      },
       "sppptun": {
-        "id": 286,
-        "loadaddr": "fffffffff84c0000",
-        "size": 14936,
+        "id": 274,
+        "loadaddr": "fffffffff81fd000",
+        "size": 12952,
         "description": "PPP 4.0 tunnel driver"
       },
+      "pit_beep": {
+        "id": 275,
+        "loadaddr": "fffffffff8159cf8",
+        "size": 1080,
+        "description": "Intel Pit_beep Driver"
+      },
+      "autofs": {
+        "id": 276,
+        "loadaddr": "fffffffff8200000",
+        "size": 31736,
+        "description": "AUTOFS syscall (32-bit)"
+      },
+      "c2audit": {
+        "id": 277,
+        "loadaddr": "fffffffff8208000",
+        "size": 74968,
+        "description": "Solaris Auditing (C2)"
+      },
+      "pset": {
+        "id": 280,
+        "loadaddr": "fffffffff8230000",
+        "size": 6112,
+        "description": "32-bit pset(2) syscall"
+      },
       "ptem": {
-        "id": 288,
-        "loadaddr": "fffffffffbdaded0",
-        "size": 5800,
+        "id": 281,
+        "loadaddr": "fffffffff7b5b278",
+        "size": 5328,
         "description": "pty hardware emulator"
       }
     }
@@ -1037,15 +1454,18 @@
   "os": "solaris2",
   "os_version": "5.11",
   "platform_version": "5.11",
-  "platform_build": "11.1",
+  "platform_build": "11.3",
   "platform": "solaris2",
   "platform_family": "solaris2",
+  "command": {
+    "ps": "ps -ef"
+  },
   "filesystem": {
     "rpool/ROOT/solaris": {
-      "kb_size": "15095808",
-      "kb_used": "3838446",
-      "kb_available": "9579675",
-      "percent_used": "29%",
+      "kb_size": "16128000",
+      "kb_used": "3118321",
+      "kb_available": "10814940",
+      "percent_used": "23%",
       "mount": "/",
       "fs_type": "zfs",
       "mount_time": "Thu Jan  1 00:00:00 1970",
@@ -1055,21 +1475,23 @@
         "setuid",
         "devices",
         "rstchown",
-        "dev=4490002"
+        "dev=4750002"
       ],
       "zfs_values": {
         "aclinherit": "restricted",
         "aclmode": "discard",
         "atime": "on",
-        "available": "9809587200",
+        "available": "11074499072",
         "canmount": "noauto",
         "casesensitivity": "mixed",
         "checksum": "on",
         "compression": "off",
         "compressratio": "1.00x",
         "copies": "1",
-        "creation": "1389615002",
+        "creation": "1457094869",
         "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
         "devices": "on",
         "encryption": "off",
         "exec": "on",
@@ -1087,7 +1509,7 @@
         "quota": "0",
         "readonly": "off",
         "recordsize": "131072",
-        "referenced": "3930569216",
+        "referenced": "3193160704",
         "refquota": "0",
         "refreservation": "0",
         "rekeydate": "-",
@@ -1100,17 +1522,18 @@
         "snapdir": "hidden",
         "sync": "standard",
         "type": "filesystem",
-        "used": "4110495744",
-        "usedbychildren": "119254528",
-        "usedbydataset": "3930569216",
+        "used": "3492963328",
+        "usedbychildren": "238431232",
+        "usedbydataset": "3193160704",
         "usedbyrefreservation": "0",
-        "usedbysnapshots": "60672000",
+        "usedbysnapshots": "61371392",
         "utf8only": "off",
         "version": "6",
         "vscan": "off",
         "xattr": "on",
         "zoned": "off",
-        "org.opensolaris.libbe:uuid": "e42f7995-403b-6147-ecd9-99082dafd73a"
+        "com.oracle.libbe:last-boot-time": "20160304T154006Z",
+        "org.opensolaris.libbe:uuid": "86d4da55-354b-4676-975f-c34670fd3da9"
       },
       "zfs_sources": {
         "aclinherit": "default",
@@ -1125,6 +1548,8 @@
         "copies": "default",
         "creation": "-",
         "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
         "devices": "default",
         "encryption": "-",
         "exec": "default",
@@ -1165,6 +1590,7 @@
         "vscan": "default",
         "xattr": "default",
         "zoned": "default",
+        "com.oracle.libbe:last-boot-time": "local",
         "org.opensolaris.libbe:uuid": "local"
       },
       "zfs_parents": [
@@ -1180,14 +1606,14 @@
       "percent_used": "0%",
       "mount": "/devices",
       "fs_type": "devfs",
-      "mount_time": "Tue Apr 29 05:42:26 2014",
+      "mount_time": "Fri Mar  4 15:39:57 2016",
       "mount_options": [
         "read",
         "write",
         "setuid",
         "devices",
         "rstchown",
-        "dev=85c0000"
+        "dev=8a40000"
       ]
     },
     "/dev": {
@@ -1197,14 +1623,14 @@
       "percent_used": "0%",
       "mount": "/dev",
       "fs_type": "dev",
-      "mount_time": "Tue Apr 29 05:42:26 2014",
+      "mount_time": "Fri Mar  4 15:39:57 2016",
       "mount_options": [
         "read",
         "write",
         "setuid",
         "devices",
         "rstchown",
-        "dev=8600000"
+        "dev=8a80000"
       ]
     },
     "ctfs": {
@@ -1214,14 +1640,14 @@
       "percent_used": "0%",
       "mount": "/system/contract",
       "fs_type": "ctfs",
-      "mount_time": "Tue Apr 29 05:42:26 2014",
+      "mount_time": "Fri Mar  4 15:39:57 2016",
       "mount_options": [
         "read",
         "write",
         "setuid",
         "devices",
         "rstchown",
-        "dev=86c0001"
+        "dev=8b40001"
       ]
     },
     "proc": {
@@ -1231,14 +1657,14 @@
       "percent_used": "0%",
       "mount": "/proc",
       "fs_type": "proc",
-      "mount_time": "Tue Apr 29 05:42:26 2014",
+      "mount_time": "Fri Mar  4 15:39:57 2016",
       "mount_options": [
         "read",
         "write",
         "setuid",
         "devices",
         "rstchown",
-        "dev=8640000"
+        "dev=8ac0000"
       ]
     },
     "mnttab": {
@@ -1248,24 +1674,24 @@
       "percent_used": "0%",
       "mount": "/etc/mnttab",
       "fs_type": "mntfs",
-      "mount_time": "Tue Apr 29 05:42:26 2014",
+      "mount_time": "Fri Mar  4 15:39:57 2016",
       "mount_options": [
         "read",
         "write",
         "setuid",
         "devices",
         "rstchown",
-        "dev=8700001"
+        "dev=8b80001"
       ]
     },
     "swap": {
-      "kb_size": "1056160",
-      "kb_used": "0",
-      "kb_available": "1056160",
-      "percent_used": "0%",
+      "kb_size": "1286396",
+      "kb_used": "60712",
+      "kb_available": "1225684",
+      "percent_used": "5%",
       "mount": "/tmp",
       "fs_type": "tmpfs",
-      "mount_time": "Tue Apr 29 05:42:32 2014",
+      "mount_time": "Fri Mar  4 15:40:06 2016",
       "mount_options": [
         "read",
         "write",
@@ -1273,7 +1699,7 @@
         "devices",
         "rstchown",
         "xattr",
-        "dev=8740002"
+        "dev=8bc0002"
       ]
     },
     "objfs": {
@@ -1283,14 +1709,14 @@
       "percent_used": "0%",
       "mount": "/system/object",
       "fs_type": "objfs",
-      "mount_time": "Tue Apr 29 05:42:26 2014",
+      "mount_time": "Fri Mar  4 15:39:57 2016",
       "mount_options": [
         "read",
         "write",
         "setuid",
         "devices",
         "rstchown",
-        "dev=8780001"
+        "dev=8c00001"
       ]
     },
     "sharefs": {
@@ -1300,31 +1726,31 @@
       "percent_used": "0%",
       "mount": "/etc/dfs/sharetab",
       "fs_type": "sharefs",
-      "mount_time": "Tue Apr 29 05:42:26 2014",
+      "mount_time": "Fri Mar  4 15:39:57 2016",
       "mount_options": [
         "read",
         "write",
         "setuid",
         "devices",
         "rstchown",
-        "dev=87c0001"
+        "dev=8c40001"
       ]
     },
     "/usr/lib/libc/libc_hwcap1.so.1": {
-      "kb_size": "13418121",
-      "kb_used": "3838446",
-      "kb_available": "9579675",
-      "percent_used": "29%",
+      "kb_size": "13933261",
+      "kb_used": "3118321",
+      "kb_available": "10814940",
+      "percent_used": "23%",
       "mount": "/lib/libc.so.1",
       "fs_type": "lofs",
-      "mount_time": "Tue Apr 29 05:42:30 2014",
+      "mount_time": "Fri Mar  4 15:40:01 2016",
       "mount_options": [
         "read",
         "write",
         "setuid",
         "devices",
         "rstchown",
-        "dev=4490002"
+        "dev=4750002"
       ]
     },
     "fd": {
@@ -1334,24 +1760,24 @@
       "percent_used": "0%",
       "mount": "/dev/fd",
       "fs_type": "fd",
-      "mount_time": "Tue Apr 29 05:42:31 2014",
+      "mount_time": "Fri Mar  4 15:40:01 2016",
       "mount_options": [
         "read",
         "write",
         "setuid",
         "devices",
         "rstchown",
-        "dev=88c0001"
+        "dev=8d40001"
       ]
     },
     "rpool/ROOT/solaris/var": {
-      "kb_size": "15095808",
-      "kb_used": "114126",
-      "kb_available": "9579675",
-      "percent_used": "2%",
+      "kb_size": "16128000",
+      "kb_used": "231804",
+      "kb_available": "10814940",
+      "percent_used": "3%",
       "mount": "/var",
       "fs_type": "zfs",
-      "mount_time": "Tue Apr 29 05:42:32 2014",
+      "mount_time": "Fri Mar  4 15:40:06 2016",
       "mount_options": [
         "read",
         "write",
@@ -1362,21 +1788,23 @@
         "exec",
         "xattr",
         "atime",
-        "dev=4490003"
+        "dev=4750004"
       ],
       "zfs_values": {
         "aclinherit": "restricted",
         "aclmode": "discard",
         "atime": "on",
-        "available": "9809587200",
+        "available": "11074499072",
         "canmount": "noauto",
         "casesensitivity": "mixed",
         "checksum": "on",
         "compression": "off",
         "compressratio": "1.00x",
         "copies": "1",
-        "creation": "1389615002",
+        "creation": "1457094869",
         "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
         "devices": "on",
         "encryption": "off",
         "exec": "on",
@@ -1394,7 +1822,7 @@
         "quota": "0",
         "readonly": "off",
         "recordsize": "131072",
-        "referenced": "116865536",
+        "referenced": "237367296",
         "refquota": "0",
         "refreservation": "0",
         "rekeydate": "-",
@@ -1407,17 +1835,18 @@
         "snapdir": "hidden",
         "sync": "standard",
         "type": "filesystem",
-        "used": "119254528",
+        "used": "238431232",
         "usedbychildren": "0",
-        "usedbydataset": "116865536",
+        "usedbydataset": "237367296",
         "usedbyrefreservation": "0",
-        "usedbysnapshots": "2388992",
+        "usedbysnapshots": "1063936",
         "utf8only": "off",
         "version": "6",
         "vscan": "off",
         "xattr": "on",
         "zoned": "off",
-        "org.opensolaris.libbe:uuid": "e42f7995-403b-6147-ecd9-99082dafd73a"
+        "com.oracle.libbe:last-boot-time": "20160304T154006Z",
+        "org.opensolaris.libbe:uuid": "86d4da55-354b-4676-975f-c34670fd3da9"
       },
       "zfs_sources": {
         "aclinherit": "default",
@@ -1432,6 +1861,8 @@
         "copies": "default",
         "creation": "-",
         "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
         "devices": "default",
         "encryption": "-",
         "exec": "default",
@@ -1441,7 +1872,7 @@
         "logbias": "default",
         "mlslabel": "-",
         "mounted": "-",
-        "mountpoint": "inherited from rpool/ROOT/solaris",
+        "mountpoint": "local",
         "multilevel": "-",
         "nbmand": "default",
         "normalization": "-",
@@ -1458,7 +1889,7 @@
         "secondarycache": "default",
         "setuid": "default",
         "shadow": "-",
-        "share.*": "inherited",
+        "share.*": "local",
         "snapdir": "default",
         "sync": "default",
         "type": "-",
@@ -1472,6 +1903,7 @@
         "vscan": "default",
         "xattr": "default",
         "zoned": "default",
+        "com.oracle.libbe:last-boot-time": "inherited from rpool/ROOT/solaris",
         "org.opensolaris.libbe:uuid": "inherited from rpool/ROOT/solaris"
       },
       "zfs_parents": [
@@ -1482,13 +1914,13 @@
       "zfs_zpool": false
     },
     "rpool/VARSHARE": {
-      "kb_size": "15095808",
-      "kb_used": "56",
-      "kb_available": "9579675",
+      "kb_size": "16128000",
+      "kb_used": "2492",
+      "kb_available": "10814940",
       "percent_used": "1%",
       "mount": "/var/share",
       "fs_type": "zfs",
-      "mount_time": "Tue Apr 29 05:42:33 2014",
+      "mount_time": "Fri Mar  4 15:40:06 2016",
       "mount_options": [
         "read",
         "write",
@@ -1499,21 +1931,23 @@
         "exec",
         "xattr",
         "atime",
-        "dev=4490004"
+        "dev=4750005"
       ],
       "zfs_values": {
         "aclinherit": "restricted",
         "aclmode": "discard",
         "atime": "on",
-        "available": "9809587200",
+        "available": "11074499072",
         "canmount": "noauto",
         "casesensitivity": "mixed",
         "checksum": "on",
         "compression": "off",
         "compressratio": "1.00x",
         "copies": "1",
-        "creation": "1389615002",
+        "creation": "1457094869",
         "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
         "devices": "on",
         "encryption": "off",
         "exec": "on",
@@ -1531,7 +1965,7 @@
         "quota": "0",
         "readonly": "off",
         "recordsize": "131072",
-        "referenced": "57344",
+        "referenced": "2552320",
         "refquota": "0",
         "refreservation": "0",
         "rekeydate": "-",
@@ -1544,9 +1978,9 @@
         "snapdir": "hidden",
         "sync": "standard",
         "type": "filesystem",
-        "used": "57344",
-        "usedbychildren": "0",
-        "usedbydataset": "57344",
+        "used": "2648576",
+        "usedbychildren": "96256",
+        "usedbydataset": "2552320",
         "usedbyrefreservation": "0",
         "usedbysnapshots": "0",
         "utf8only": "off",
@@ -1568,6 +2002,8 @@
         "copies": "default",
         "creation": "-",
         "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
         "devices": "default",
         "encryption": "-",
         "exec": "default",
@@ -1615,13 +2051,13 @@
       "zfs_zpool": false
     },
     "rpool/export": {
-      "kb_size": "15095808",
+      "kb_size": "16128000",
       "kb_used": "32",
-      "kb_available": "9579675",
+      "kb_available": "10814940",
       "percent_used": "1%",
       "mount": "/export",
       "fs_type": "zfs",
-      "mount_time": "Tue Apr 29 05:42:41 2014",
+      "mount_time": "Fri Mar  4 15:40:15 2016",
       "mount_options": [
         "read",
         "write",
@@ -1632,21 +2068,23 @@
         "exec",
         "xattr",
         "atime",
-        "dev=4490005"
+        "dev=4750006"
       ],
       "zfs_values": {
         "aclinherit": "restricted",
         "aclmode": "discard",
         "atime": "on",
-        "available": "9809587200",
+        "available": "11074499072",
         "canmount": "on",
         "casesensitivity": "mixed",
         "checksum": "on",
         "compression": "off",
         "compressratio": "1.00x",
         "copies": "1",
-        "creation": "1389615001",
+        "creation": "1457094869",
         "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
         "devices": "on",
         "encryption": "off",
         "exec": "on",
@@ -1677,8 +2115,8 @@
         "snapdir": "hidden",
         "sync": "standard",
         "type": "filesystem",
-        "used": "8534528",
-        "usedbychildren": "8501760",
+        "used": "705024",
+        "usedbychildren": "672256",
         "usedbydataset": "32768",
         "usedbyrefreservation": "0",
         "usedbysnapshots": "0",
@@ -1701,6 +2139,8 @@
         "copies": "default",
         "creation": "-",
         "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
         "devices": "default",
         "encryption": "-",
         "exec": "default",
@@ -1748,13 +2188,13 @@
       "zfs_zpool": false
     },
     "rpool/export/home": {
-      "kb_size": "15095808",
+      "kb_size": "16128000",
       "kb_used": "32",
-      "kb_available": "9579675",
+      "kb_available": "10814940",
       "percent_used": "1%",
       "mount": "/export/home",
       "fs_type": "zfs",
-      "mount_time": "Tue Apr 29 05:42:41 2014",
+      "mount_time": "Fri Mar  4 15:40:15 2016",
       "mount_options": [
         "read",
         "write",
@@ -1765,21 +2205,23 @@
         "exec",
         "xattr",
         "atime",
-        "dev=4490006"
+        "dev=4750007"
       ],
       "zfs_values": {
         "aclinherit": "restricted",
         "aclmode": "discard",
         "atime": "on",
-        "available": "9809587200",
+        "available": "11074499072",
         "canmount": "on",
         "casesensitivity": "mixed",
         "checksum": "on",
         "compression": "off",
         "compressratio": "1.00x",
         "copies": "1",
-        "creation": "1389615002",
+        "creation": "1457094869",
         "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
         "devices": "on",
         "encryption": "off",
         "exec": "on",
@@ -1810,8 +2252,8 @@
         "snapdir": "hidden",
         "sync": "standard",
         "type": "filesystem",
-        "used": "8501760",
-        "usedbychildren": "8468992",
+        "used": "672256",
+        "usedbychildren": "639488",
         "usedbydataset": "32768",
         "usedbyrefreservation": "0",
         "usedbysnapshots": "0",
@@ -1834,6 +2276,8 @@
         "copies": "default",
         "creation": "-",
         "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
         "devices": "default",
         "encryption": "-",
         "exec": "default",
@@ -1881,14 +2325,14 @@
       ],
       "zfs_zpool": false
     },
-    "rpool/export/home/vagrant": {
-      "kb_size": "15095808",
-      "kb_used": "8270",
-      "kb_available": "9579675",
+    "rpool/export/home/tsmith": {
+      "kb_size": "16128000",
+      "kb_used": "624",
+      "kb_available": "10814940",
       "percent_used": "1%",
-      "mount": "/export/home/vagrant",
+      "mount": "/export/home/tsmith",
       "fs_type": "zfs",
-      "mount_time": "Tue Apr 29 05:42:41 2014",
+      "mount_time": "Fri Mar  4 15:40:15 2016",
       "mount_options": [
         "read",
         "write",
@@ -1899,21 +2343,23 @@
         "exec",
         "xattr",
         "atime",
-        "dev=4490007"
+        "dev=4750008"
       ],
       "zfs_values": {
         "aclinherit": "restricted",
         "aclmode": "discard",
         "atime": "on",
-        "available": "9809587200",
+        "available": "11074499072",
         "canmount": "on",
         "casesensitivity": "mixed",
         "checksum": "on",
         "compression": "off",
         "compressratio": "1.00x",
         "copies": "1",
-        "creation": "1389617218",
+        "creation": "1457095547",
         "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
         "devices": "on",
         "encryption": "off",
         "exec": "on",
@@ -1923,7 +2369,7 @@
         "logbias": "latency",
         "mlslabel": "none",
         "mounted": "yes",
-        "mountpoint": "/export/home/vagrant",
+        "mountpoint": "/export/home/tsmith",
         "multilevel": "off",
         "nbmand": "off",
         "normalization": "none",
@@ -1931,7 +2377,7 @@
         "quota": "0",
         "readonly": "off",
         "recordsize": "131072",
-        "referenced": "8468992",
+        "referenced": "639488",
         "refquota": "0",
         "refreservation": "0",
         "rekeydate": "-",
@@ -1944,9 +2390,9 @@
         "snapdir": "hidden",
         "sync": "standard",
         "type": "filesystem",
-        "used": "8468992",
+        "used": "639488",
         "usedbychildren": "0",
-        "usedbydataset": "8468992",
+        "usedbydataset": "639488",
         "usedbyrefreservation": "0",
         "usedbysnapshots": "0",
         "utf8only": "off",
@@ -1968,6 +2414,8 @@
         "copies": "default",
         "creation": "-",
         "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
         "devices": "default",
         "encryption": "-",
         "exec": "default",
@@ -2017,13 +2465,13 @@
       "zfs_zpool": false
     },
     "rpool": {
-      "kb_size": "15095808",
-      "kb_used": "4685",
-      "kb_available": "9579675",
+      "kb_size": "16128000",
+      "kb_used": "4630",
+      "kb_available": "10814940",
       "percent_used": "1%",
       "mount": "/rpool",
       "fs_type": "zfs",
-      "mount_time": "Tue Apr 29 05:42:41 2014",
+      "mount_time": "Fri Mar  4 15:40:15 2016",
       "mount_options": [
         "read",
         "write",
@@ -2034,21 +2482,23 @@
         "exec",
         "xattr",
         "atime",
-        "dev=4490008"
+        "dev=4750009"
       ],
       "zfs_values": {
         "aclinherit": "restricted",
         "aclmode": "discard",
         "atime": "on",
-        "available": "9809587200",
+        "available": "11074499072",
         "canmount": "on",
         "casesensitivity": "mixed",
         "checksum": "on",
         "compression": "off",
         "compressratio": "1.00x",
         "copies": "1",
-        "creation": "1389615001",
+        "creation": "1457094869",
         "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
         "devices": "on",
         "encryption": "off",
         "exec": "on",
@@ -2066,7 +2516,7 @@
         "quota": "0",
         "readonly": "off",
         "recordsize": "131072",
-        "referenced": "4797952",
+        "referenced": "4741632",
         "refquota": "0",
         "refreservation": "0",
         "rekeydate": "-",
@@ -2079,9 +2529,9 @@
         "snapdir": "hidden",
         "sync": "standard",
         "type": "filesystem",
-        "used": "5648520192",
-        "usedbychildren": "5643722240",
-        "usedbydataset": "4797952",
+        "used": "5440572928",
+        "usedbychildren": "5435831296",
+        "usedbydataset": "4741632",
         "usedbyrefreservation": "0",
         "usedbysnapshots": "0",
         "utf8only": "off",
@@ -2103,6 +2553,8 @@
         "copies": "default",
         "creation": "-",
         "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
         "devices": "default",
         "encryption": "-",
         "exec": "default",
@@ -2149,6 +2601,421 @@
       ],
       "zfs_zpool": true
     },
+    "rpool/VARSHARE/zones": {
+      "kb_size": "16128000",
+      "kb_used": "31",
+      "kb_available": "10814940",
+      "percent_used": "1%",
+      "mount": "/system/zones",
+      "fs_type": "zfs",
+      "mount_time": "Fri Mar  4 15:40:15 2016",
+      "mount_options": [
+        "read",
+        "write",
+        "setuid",
+        "devices",
+        "rstchown",
+        "nonbmand",
+        "exec",
+        "xattr",
+        "atime",
+        "dev=475000a"
+      ],
+      "zfs_values": {
+        "aclinherit": "restricted",
+        "aclmode": "discard",
+        "atime": "on",
+        "available": "11074499072",
+        "canmount": "on",
+        "casesensitivity": "mixed",
+        "checksum": "on",
+        "compression": "off",
+        "compressratio": "1.00x",
+        "copies": "1",
+        "creation": "1457095538",
+        "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
+        "devices": "on",
+        "encryption": "off",
+        "exec": "on",
+        "keychangedate": "-",
+        "keysource": "none",
+        "keystatus": "none",
+        "logbias": "latency",
+        "mlslabel": "none",
+        "mounted": "yes",
+        "mountpoint": "/system/zones",
+        "multilevel": "off",
+        "nbmand": "off",
+        "normalization": "none",
+        "primarycache": "all",
+        "quota": "0",
+        "readonly": "off",
+        "recordsize": "131072",
+        "referenced": "31744",
+        "refquota": "0",
+        "refreservation": "0",
+        "rekeydate": "-",
+        "reservation": "0",
+        "rstchown": "on",
+        "secondarycache": "all",
+        "setuid": "on",
+        "shadow": "none",
+        "share.*": "...",
+        "snapdir": "hidden",
+        "sync": "standard",
+        "type": "filesystem",
+        "used": "31744",
+        "usedbychildren": "0",
+        "usedbydataset": "31744",
+        "usedbyrefreservation": "0",
+        "usedbysnapshots": "0",
+        "utf8only": "off",
+        "version": "6",
+        "vscan": "off",
+        "xattr": "on",
+        "zoned": "off"
+      },
+      "zfs_sources": {
+        "aclinherit": "default",
+        "aclmode": "default",
+        "atime": "default",
+        "available": "-",
+        "canmount": "default",
+        "casesensitivity": "-",
+        "checksum": "default",
+        "compression": "default",
+        "compressratio": "-",
+        "copies": "default",
+        "creation": "-",
+        "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
+        "devices": "default",
+        "encryption": "-",
+        "exec": "default",
+        "keychangedate": "default",
+        "keysource": "default",
+        "keystatus": "-",
+        "logbias": "default",
+        "mlslabel": "-",
+        "mounted": "-",
+        "mountpoint": "local",
+        "multilevel": "-",
+        "nbmand": "default",
+        "normalization": "-",
+        "primarycache": "default",
+        "quota": "default",
+        "readonly": "default",
+        "recordsize": "default",
+        "referenced": "-",
+        "refquota": "default",
+        "refreservation": "default",
+        "rekeydate": "default",
+        "reservation": "default",
+        "rstchown": "default",
+        "secondarycache": "default",
+        "setuid": "default",
+        "shadow": "-",
+        "share.*": "local",
+        "snapdir": "default",
+        "sync": "default",
+        "type": "-",
+        "used": "-",
+        "usedbychildren": "-",
+        "usedbydataset": "-",
+        "usedbyrefreservation": "-",
+        "usedbysnapshots": "-",
+        "utf8only": "-",
+        "version": "-",
+        "vscan": "default",
+        "xattr": "default",
+        "zoned": "default"
+      },
+      "zfs_parents": [
+        "rpool",
+        "rpool/VARSHARE"
+      ],
+      "zfs_zpool": false
+    },
+    "rpool/VARSHARE/pkg": {
+      "kb_size": "16128000",
+      "kb_used": "32",
+      "kb_available": "10814940",
+      "percent_used": "1%",
+      "mount": "/var/share/pkg",
+      "fs_type": "zfs",
+      "mount_time": "Fri Mar  4 15:40:16 2016",
+      "mount_options": [
+        "read",
+        "write",
+        "setuid",
+        "devices",
+        "rstchown",
+        "nonbmand",
+        "exec",
+        "xattr",
+        "atime",
+        "dev=475000b"
+      ],
+      "zfs_values": {
+        "aclinherit": "restricted",
+        "aclmode": "discard",
+        "atime": "on",
+        "available": "11074499072",
+        "canmount": "noauto",
+        "casesensitivity": "mixed",
+        "checksum": "on",
+        "compression": "off",
+        "compressratio": "1.00x",
+        "copies": "1",
+        "creation": "1457095553",
+        "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
+        "devices": "on",
+        "encryption": "off",
+        "exec": "on",
+        "keychangedate": "-",
+        "keysource": "none",
+        "keystatus": "none",
+        "logbias": "latency",
+        "mlslabel": "none",
+        "mounted": "yes",
+        "mountpoint": "/var/share/pkg",
+        "multilevel": "off",
+        "nbmand": "off",
+        "normalization": "none",
+        "primarycache": "all",
+        "quota": "0",
+        "readonly": "off",
+        "recordsize": "131072",
+        "referenced": "32768",
+        "refquota": "0",
+        "refreservation": "0",
+        "rekeydate": "-",
+        "reservation": "0",
+        "rstchown": "on",
+        "secondarycache": "all",
+        "setuid": "on",
+        "shadow": "none",
+        "share.*": "...",
+        "snapdir": "hidden",
+        "sync": "standard",
+        "type": "filesystem",
+        "used": "64512",
+        "usedbychildren": "31744",
+        "usedbydataset": "32768",
+        "usedbyrefreservation": "0",
+        "usedbysnapshots": "0",
+        "utf8only": "off",
+        "version": "6",
+        "vscan": "off",
+        "xattr": "on",
+        "zoned": "off"
+      },
+      "zfs_sources": {
+        "aclinherit": "default",
+        "aclmode": "default",
+        "atime": "default",
+        "available": "-",
+        "canmount": "local",
+        "casesensitivity": "-",
+        "checksum": "default",
+        "compression": "default",
+        "compressratio": "-",
+        "copies": "default",
+        "creation": "-",
+        "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
+        "devices": "default",
+        "encryption": "-",
+        "exec": "default",
+        "keychangedate": "default",
+        "keysource": "default",
+        "keystatus": "-",
+        "logbias": "default",
+        "mlslabel": "-",
+        "mounted": "-",
+        "mountpoint": "inherited from rpool/VARSHARE",
+        "multilevel": "-",
+        "nbmand": "default",
+        "normalization": "-",
+        "primarycache": "default",
+        "quota": "default",
+        "readonly": "default",
+        "recordsize": "default",
+        "referenced": "-",
+        "refquota": "default",
+        "refreservation": "default",
+        "rekeydate": "default",
+        "reservation": "default",
+        "rstchown": "default",
+        "secondarycache": "default",
+        "setuid": "default",
+        "shadow": "-",
+        "share.*": "inherited",
+        "snapdir": "default",
+        "sync": "default",
+        "type": "-",
+        "used": "-",
+        "usedbychildren": "-",
+        "usedbydataset": "-",
+        "usedbyrefreservation": "-",
+        "usedbysnapshots": "-",
+        "utf8only": "-",
+        "version": "-",
+        "vscan": "default",
+        "xattr": "default",
+        "zoned": "default"
+      },
+      "zfs_parents": [
+        "rpool",
+        "rpool/VARSHARE"
+      ],
+      "zfs_zpool": false
+    },
+    "rpool/VARSHARE/pkg/repositories": {
+      "kb_size": "16128000",
+      "kb_used": "31",
+      "kb_available": "10814940",
+      "percent_used": "1%",
+      "mount": "/var/share/pkg/repositories",
+      "fs_type": "zfs",
+      "mount_time": "Fri Mar  4 15:40:16 2016",
+      "mount_options": [
+        "read",
+        "write",
+        "setuid",
+        "devices",
+        "rstchown",
+        "nonbmand",
+        "exec",
+        "xattr",
+        "atime",
+        "dev=475000c"
+      ],
+      "zfs_values": {
+        "aclinherit": "restricted",
+        "aclmode": "discard",
+        "atime": "on",
+        "available": "11074499072",
+        "canmount": "noauto",
+        "casesensitivity": "mixed",
+        "checksum": "on",
+        "compression": "off",
+        "compressratio": "1.00x",
+        "copies": "1",
+        "creation": "1457095554",
+        "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
+        "devices": "on",
+        "encryption": "off",
+        "exec": "on",
+        "keychangedate": "-",
+        "keysource": "none",
+        "keystatus": "none",
+        "logbias": "latency",
+        "mlslabel": "none",
+        "mounted": "yes",
+        "mountpoint": "/var/share/pkg/repositories",
+        "multilevel": "off",
+        "nbmand": "off",
+        "normalization": "none",
+        "primarycache": "all",
+        "quota": "0",
+        "readonly": "off",
+        "recordsize": "131072",
+        "referenced": "31744",
+        "refquota": "0",
+        "refreservation": "0",
+        "rekeydate": "-",
+        "reservation": "0",
+        "rstchown": "on",
+        "secondarycache": "all",
+        "setuid": "on",
+        "shadow": "none",
+        "share.*": "...",
+        "snapdir": "hidden",
+        "sync": "standard",
+        "type": "filesystem",
+        "used": "31744",
+        "usedbychildren": "0",
+        "usedbydataset": "31744",
+        "usedbyrefreservation": "0",
+        "usedbysnapshots": "0",
+        "utf8only": "off",
+        "version": "6",
+        "vscan": "off",
+        "xattr": "on",
+        "zoned": "off"
+      },
+      "zfs_sources": {
+        "aclinherit": "default",
+        "aclmode": "default",
+        "atime": "default",
+        "available": "-",
+        "canmount": "local",
+        "casesensitivity": "-",
+        "checksum": "default",
+        "compression": "default",
+        "compressratio": "-",
+        "copies": "default",
+        "creation": "-",
+        "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
+        "devices": "default",
+        "encryption": "-",
+        "exec": "default",
+        "keychangedate": "default",
+        "keysource": "default",
+        "keystatus": "-",
+        "logbias": "default",
+        "mlslabel": "-",
+        "mounted": "-",
+        "mountpoint": "inherited from rpool/VARSHARE",
+        "multilevel": "-",
+        "nbmand": "default",
+        "normalization": "-",
+        "primarycache": "default",
+        "quota": "default",
+        "readonly": "default",
+        "recordsize": "default",
+        "referenced": "-",
+        "refquota": "default",
+        "refreservation": "default",
+        "rekeydate": "default",
+        "reservation": "default",
+        "rstchown": "default",
+        "secondarycache": "default",
+        "setuid": "default",
+        "shadow": "-",
+        "share.*": "inherited",
+        "snapdir": "default",
+        "sync": "default",
+        "type": "-",
+        "used": "-",
+        "usedbychildren": "-",
+        "usedbydataset": "-",
+        "usedbyrefreservation": "-",
+        "usedbysnapshots": "-",
+        "utf8only": "-",
+        "version": "-",
+        "vscan": "default",
+        "xattr": "default",
+        "zoned": "default"
+      },
+      "zfs_parents": [
+        "rpool",
+        "rpool/VARSHARE",
+        "rpool/VARSHARE/pkg"
+      ],
+      "zfs_zpool": false
+    },
     "-hosts": {
       "kb_size": "0",
       "kb_used": "0",
@@ -2173,23 +3040,6 @@
       "mount": "/nfs4",
       "fs_type": "autofs"
     },
-    "/export/home/vagrant": {
-      "kb_size": "9587945",
-      "kb_used": "8270",
-      "kb_available": "9579675",
-      "percent_used": "1%",
-      "mount": "/home/vagrant",
-      "fs_type": "lofs",
-      "mount_time": "Tue Apr 29 15:02:28 2014",
-      "mount_options": [
-        "read",
-        "write",
-        "setuid",
-        "devices",
-        "rstchown",
-        "dev=4490007"
-      ]
-    },
     "rpool/ROOT": {
       "fs_type": "zfs",
       "mount": "legacy",
@@ -2197,15 +3047,17 @@
         "aclinherit": "restricted",
         "aclmode": "discard",
         "atime": "on",
-        "available": "9809587200",
+        "available": "11074499072",
         "canmount": "off",
         "casesensitivity": "mixed",
         "checksum": "on",
         "compression": "off",
         "compressratio": "1.00x",
         "copies": "1",
-        "creation": "1389615002",
+        "creation": "1457094869",
         "dedup": "off",
+        "defaultgroupquota": "0",
+        "defaultuserquota": "0",
         "devices": "on",
         "encryption": "off",
         "exec": "on",
@@ -2237,8 +3089,8 @@
         "snapdir": "hidden",
         "sync": "standard",
         "type": "filesystem",
-        "used": "4110527488",
-        "usedbychildren": "4110495744",
+        "used": "3492995072",
+        "usedbychildren": "3492963328",
         "usedbydataset": "31744",
         "usedbyrefreservation": "0",
         "usedbysnapshots": "0",
@@ -2261,6 +3113,8 @@
         "copies": "default",
         "creation": "-",
         "dedup": "default",
+        "defaultgroupquota": "-",
+        "defaultuserquota": "-",
         "devices": "default",
         "encryption": "-",
         "exec": "default",
@@ -2313,7 +3167,7 @@
       "zfs_values": {
         "casesensitivity": "mixed",
         "compressratio": "1.00x",
-        "creation": "1389617126",
+        "creation": "1457095178",
         "defer_destroy": "off",
         "devices": "on",
         "encryption": "off",
@@ -2324,17 +3178,18 @@
         "nbmand": "off",
         "normalization": "none",
         "primarycache": "all",
-        "referenced": "3653717504",
+        "referenced": "2864948224",
         "rstchown": "on",
         "secondarycache": "all",
         "setuid": "on",
         "type": "snapshot",
-        "used": "60672000",
+        "used": "61371392",
         "userrefs": "0",
         "utf8only": "off",
         "version": "6",
         "xattr": "on",
-        "org.opensolaris.libbe:uuid": "e42f7995-403b-6147-ecd9-99082dafd73a",
+        "com.oracle.libbe:last-boot-time": "20160304T154006Z",
+        "org.opensolaris.libbe:uuid": "86d4da55-354b-4676-975f-c34670fd3da9",
         "org.opensolaris.libbe:policy": "static"
       },
       "zfs_sources": {
@@ -2361,6 +3216,7 @@
         "utf8only": "-",
         "version": "-",
         "xattr": "default",
+        "com.oracle.libbe:last-boot-time": "inherited from rpool/ROOT/solaris",
         "org.opensolaris.libbe:uuid": "inherited from rpool/ROOT/solaris",
         "org.opensolaris.libbe:policy": "local"
       },
@@ -2375,7 +3231,7 @@
       "zfs_values": {
         "casesensitivity": "mixed",
         "compressratio": "1.00x",
-        "creation": "1389617126",
+        "creation": "1457095178",
         "defer_destroy": "off",
         "devices": "on",
         "encryption": "off",
@@ -2386,17 +3242,18 @@
         "nbmand": "off",
         "normalization": "none",
         "primarycache": "all",
-        "referenced": "111765504",
+        "referenced": "230137856",
         "rstchown": "on",
         "secondarycache": "all",
         "setuid": "on",
         "type": "snapshot",
-        "used": "2388992",
+        "used": "1063936",
         "userrefs": "0",
         "utf8only": "off",
         "version": "6",
         "xattr": "on",
-        "org.opensolaris.libbe:uuid": "e42f7995-403b-6147-ecd9-99082dafd73a",
+        "com.oracle.libbe:last-boot-time": "20160304T154006Z",
+        "org.opensolaris.libbe:uuid": "86d4da55-354b-4676-975f-c34670fd3da9",
         "org.opensolaris.libbe:policy": "static"
       },
       "zfs_sources": {
@@ -2423,6 +3280,7 @@
         "utf8only": "-",
         "version": "-",
         "xattr": "default",
+        "com.oracle.libbe:last-boot-time": "inherited from rpool/ROOT/solaris",
         "org.opensolaris.libbe:uuid": "inherited from rpool/ROOT/solaris",
         "org.opensolaris.libbe:policy": "local"
       },
@@ -2436,12 +3294,12 @@
     "rpool/dump": {
       "fs_type": "zfs",
       "zfs_values": {
-        "available": "9822507008",
+        "available": "11100091904",
         "checksum": "off",
         "compression": "off",
         "compressratio": "1.00x",
         "copies": "1",
-        "creation": "1389615002",
+        "creation": "1457094870",
         "dedup": "off",
         "encryption": "off",
         "keychangedate": "-",
@@ -2450,20 +3308,20 @@
         "logbias": "latency",
         "primarycache": "all",
         "readonly": "off",
-        "referenced": "402676736",
-        "refreservation": "415596544",
+        "referenced": "805338112",
+        "refreservation": "830930944",
         "rekeydate": "-",
         "reservation": "0",
         "secondarycache": "all",
         "sync": "standard",
         "type": "volume",
-        "used": "415596544",
+        "used": "830930944",
         "usedbychildren": "0",
-        "usedbydataset": "402676736",
-        "usedbyrefreservation": "12919808",
+        "usedbydataset": "805338112",
+        "usedbyrefreservation": "25592832",
         "usedbysnapshots": "0",
         "volblocksize": "1048576",
-        "volsize": "402653184",
+        "volsize": "805306368",
         "zoned": "off"
       },
       "zfs_sources": {
@@ -2505,12 +3363,12 @@
     "rpool/swap": {
       "fs_type": "zfs",
       "zfs_values": {
-        "available": "9843631104",
+        "available": "11108542976",
         "checksum": "off",
         "compression": "off",
         "compressratio": "1.00x",
         "copies": "1",
-        "creation": "1389615003",
+        "creation": "1457094872",
         "dedup": "off",
         "encryption": "off",
         "keychangedate": "-",
@@ -2572,28 +3430,25 @@
       "zfs_zpool": false
     }
   },
-  "ohai_time": 1398784848.095432,
-  "dmi": {
-  },
-  "command": {
-    "ps": "ps -ef"
-  },
+  "root_group": "root",
+  "ohai_time": 1457119922.5146904,
   "languages": {
     "ruby": {
       "bin_dir": "/usr/local/bin",
       "gem_bin": "/usr/local/bin/gem",
       "gems_dir": "/usr/local/gems",
       "ruby_bin": "/usr/local/bin/ruby"
-    }
+    },
+    "powershell": null
   },
   "chef_packages": {
     "chef": {
-      "version": "11.12.2",
-      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-11.12.2/lib"
+      "version": "12.8.1",
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.8.1/lib"
     },
     "ohai": {
-      "version": "7.0.2",
-      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-7.0.2/lib/ohai"
+      "version": "8.11.1",
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.11.1/lib/ohai"
     }
   },
   "counters": {
@@ -2702,6 +3557,10 @@
     "cores": 1
   },
   "memory": {
-    "total": "512"
+    "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
   }
 }


### PR DESCRIPTION
The 5.11 data  was about 2 years old.  The 5.10 data was newer, but was captured with an old Fauxhai release.  I fixed that data up by hand a bit.