### PR TITLE
Update RAW_BASE URL.

### DIFF
--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -5,7 +5,7 @@ require 'open-uri'
 module Fauxhai
   class Mocker
     # The base URL for the GitHub project (raw)
-    RAW_BASE = 'https://raw.github.com/customink/fauxhai/master'
+    RAW_BASE = 'https://raw.githubusercontent.com/customink/fauxhai/master'
 
     # @return [Hash] The raw ohai data for the given Mock
     attr_reader :data


### PR DESCRIPTION
For security reasons, GitHub prefers people using the https://raw.githubusercontent.com URL for raw content.

For details, see: https://developer.github.com/changes/2014-04-25-user-content-security/