### PR TITLE
Add dump from modern Arch

### DIFF
--- a/lib/fauxhai/platforms/arch/4.5.4-1-ARCH.json
+++ b/lib/fauxhai/platforms/arch/4.5.4-1-ARCH.json
@@ -1,0 +1,675 @@
+{
+  "command": {
+    "ps": "ps -ef"
+  },
+  "kernel": {
+    "name": "Linux",
+    "release": "4.5.4-1-ARCH",
+    "version": "#1 SMP PREEMPT Wed May 11 22:21:28 CEST 2016",
+    "machine": "x86_64",
+    "processor": "unknown",
+    "os": "GNU/Linux",
+    "modules": {
+      "cfg80211": {
+        "size": "491520",
+        "refcount": "0"
+      },
+      "rfkill": {
+        "size": "20480",
+        "refcount": "2"
+      },
+      "crct10dif_pclmul": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "ppdev": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "crc32_pclmul": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "crc32c_intel": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "ghash_clmulni_intel": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "joydev": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "aesni_intel": {
+        "size": "167936",
+        "refcount": "0"
+      },
+      "mousedev": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "aes_x86_64": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "lrw": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_intel8x0": {
+        "size": "36864",
+        "refcount": "0"
+      },
+      "gf128mul": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "glue_helper": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_ac97_codec": {
+        "size": "118784",
+        "refcount": "1"
+      },
+      "ablk_helper": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "cryptd": {
+        "size": "20480",
+        "refcount": "3"
+      },
+      "intel_agp": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "i2c_piix4": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "ac97_bus": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "e1000": {
+        "size": "122880",
+        "refcount": "0"
+      },
+      "intel_gtt": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "snd_pcm": {
+        "size": "86016",
+        "refcount": "2"
+      },
+      "snd_timer": {
+        "size": "28672",
+        "refcount": "1"
+      },
+      "snd": {
+        "size": "65536",
+        "refcount": "4"
+      },
+      "soundcore": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "pcspkr": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "psmouse": {
+        "size": "118784",
+        "refcount": "0"
+      },
+      "evdev": {
+        "size": "24576",
+        "refcount": "3"
+      },
+      "input_leds": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "led_class": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "mac_hid": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "acpi_cpufreq": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "tpm_tis": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "tpm": {
+        "size": "36864",
+        "refcount": "1"
+      },
+      "fjes": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "battery": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "parport_pc": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "parport": {
+        "size": "40960",
+        "refcount": "2"
+      },
+      "ac": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "video": {
+        "size": "36864",
+        "refcount": "0"
+      },
+      "processor": {
+        "size": "32768",
+        "refcount": "1"
+      },
+      "button": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "sch_fq_codel": {
+        "size": "20480",
+        "refcount": "2"
+      },
+      "ip_tables": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "x_tables": {
+        "size": "28672",
+        "refcount": "1"
+      },
+      "ext4": {
+        "size": "516096",
+        "refcount": "1"
+      },
+      "crc16": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "mbcache": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "jbd2": {
+        "size": "94208",
+        "refcount": "1"
+      },
+      "hid_generic": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "usbhid": {
+        "size": "45056",
+        "refcount": "0"
+      },
+      "hid": {
+        "size": "114688",
+        "refcount": "2"
+      },
+      "sd_mod": {
+        "size": "36864",
+        "refcount": "3"
+      },
+      "sr_mod": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "cdrom": {
+        "size": "49152",
+        "refcount": "1"
+      },
+      "ata_generic": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "pata_acpi": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "atkbd": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "libps2": {
+        "size": "16384",
+        "refcount": "2"
+      },
+      "ahci": {
+        "size": "36864",
+        "refcount": "2"
+      },
+      "libahci": {
+        "size": "28672",
+        "refcount": "1"
+      },
+      "ata_piix": {
+        "size": "36864",
+        "refcount": "0"
+      },
+      "i8042": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "serio": {
+        "size": "20480",
+        "refcount": "6"
+      },
+      "ohci_pci": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "ohci_hcd": {
+        "size": "45056",
+        "refcount": "1"
+      },
+      "libata": {
+        "size": "196608",
+        "refcount": "5"
+      },
+      "scsi_mod": {
+        "size": "151552",
+        "refcount": "3"
+      },
+      "usbcore": {
+        "size": "196608",
+        "refcount": "3"
+      },
+      "usb_common": {
+        "size": "16384",
+        "refcount": "1"
+      }
+    }
+  },
+  "os": "linux",
+  "os_version": "4.5.4-1-ARCH",
+  "lsb": {
+  },
+  "platform": "arch",
+  "platform_version": "4.5.4-1-ARCH",
+  "platform_family": "arch",
+  "filesystem": {
+    "dev": {
+      "kb_size": "379108",
+      "kb_used": "0",
+      "kb_available": "379108",
+      "percent_used": "0%",
+      "mount": "/dev",
+      "total_inodes": "94777",
+      "inodes_used": "329",
+      "inodes_available": "94448",
+      "inodes_percent_used": "1%",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "relatime",
+        "size=379108k",
+        "nr_inodes=94777",
+        "mode=755"
+      ]
+    },
+    "run": {
+      "kb_size": "381648",
+      "kb_used": "308",
+      "kb_available": "381340",
+      "percent_used": "1%",
+      "mount": "/run",
+      "total_inodes": "95412",
+      "inodes_used": "333",
+      "inodes_available": "95079",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "mode=755"
+      ]
+    },
+    "/dev/sda1": {
+      "kb_size": "101016992",
+      "kb_used": "1355572",
+      "kb_available": "94507016",
+      "percent_used": "2%",
+      "mount": "/",
+      "total_inodes": "6422528",
+      "inodes_used": "71186",
+      "inodes_available": "6351342",
+      "inodes_percent_used": "2%",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "data=ordered"
+      ],
+      "uuid": "30f687a1-a52e-417c-a054-323265147108"
+    },
+    "tmpfs": {
+      "kb_size": "76332",
+      "kb_used": "0",
+      "kb_available": "76332",
+      "percent_used": "0%",
+      "mount": "/run/user/0",
+      "total_inodes": "95412",
+      "inodes_used": "5",
+      "inodes_available": "95407",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=76332k",
+        "mode=700"
+      ]
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "sys": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "securityfs": {
+      "mount": "/sys/kernel/security",
+      "fs_type": "securityfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ]
+    },
+    "cgroup": {
+      "mount": "/sys/fs/cgroup/net_cls",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "net_cls"
+      ]
+    },
+    "pstore": {
+      "mount": "/sys/fs/pstore",
+      "fs_type": "pstore",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "systemd-1": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "autofs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "fd=27",
+        "pgrp=1",
+        "timeout=0",
+        "minproto=5",
+        "maxproto=5",
+        "direct"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "configfs": {
+      "mount": "/sys/kernel/config",
+      "fs_type": "configfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "mqueue": {
+      "mount": "/dev/mqueue",
+      "fs_type": "mqueue",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "hugetlbfs": {
+      "mount": "/dev/hugepages",
+      "fs_type": "hugetlbfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "binfmt_misc": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "binfmt_misc",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "tracefs": {
+      "mount": "/sys/kernel/debug/tracing",
+      "fs_type": "tracefs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "/dev/sda2": {
+      "fs_type": "swap",
+      "uuid": "faf43134-79b1-479d-8e3b-fb7e1b954c9b"
+    }
+  },
+  "dmi": {
+  },
+  "ohai_time": 1464378973.6190536,
+  "init_package": "systemd",
+  "root_group": "root",
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-linux",
+      "version": "2.3.1",
+      "release_date": "2016-04-26",
+      "target": "x86_64-pc-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "pc",
+      "target_os": "linux",
+      "host": "x86_64-pc-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux-gnu",
+      "host_vendor": "pc",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gems_dir": "/usr/local/gems",
+      "gem_bin": "/usr/local/bin/gem"
+    },
+    "powershell": null
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "12.10.24",
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib"
+    },
+    "ohai": {
+      "version": "8.16.0",
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.16.0/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "settings": {
+    },
+    "interfaces": {
+      "eth0": {
+        "addresses": {
+          "10.0.0.2": {
+            "broadcast": "10.0.0.255",
+            "family": "inet",
+            "netmask": "255.255.255.0",
+            "prefixlen": "23",
+            "scope": "Global"
+          }
+        },
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "encapsulation": "Ethernet",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "1500",
+        "number": "0",
+        "routes": {
+          "10.0.0.0/255": {
+            "scope": "link",
+            "src": "10.0.0.2"
+          }
+        },
+        "state": "up",
+        "type": "eth"
+      }
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "cpu": {
+    "real": 1,
+    "total": 1,
+    "cores": 1
+  },
+  "memory": {
+    "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
+  }
+}


### PR DESCRIPTION
Our last dump is still on Chef 11 and lacks basic things like root_group