### PR TITLE
Remove support for Ruby 1.9

### DIFF
--- a/fauxhai.gemspec
+++ b/fauxhai.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/customink/fauxhai'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 1.9'
+  spec.required_ruby_version = '>= 2.0'
 
   spec.files         = `git ls-files`.split($\)
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }


### PR DESCRIPTION
It's been EoL for over a year now