### PR TITLE
Add a slightly newer Gentoo

### DIFF
--- a/lib/fauxhai/platforms/gentoo/2.2.json
+++ b/lib/fauxhai/platforms/gentoo/2.2.json
@@ -1,0 +1,413 @@
+{
+  "kernel": {
+    "name": "Linux",
+    "release": "3.18.7-gentoo",
+    "version": "#1 SMP Wed Mar 11 17:58:50 GMT 2015",
+    "machine": "x86_64",
+    "processor": "Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz",
+    "os": "GNU/Linux",
+    "modules": {
+    }
+  },
+  "dmi": {
+  },
+  "ohai_time": 1464391550.7510288,
+  "command": {
+    "ps": "ps -ef"
+  },
+  "lsb": {
+  },
+  "os": "linux",
+  "os_version": "3.18.7-gentoo",
+  "platform": "gentoo",
+  "platform_version": "2.2",
+  "platform_family": "gentoo",
+  "filesystem": {
+    "/dev/sda1": {
+      "kb_size": "49410864",
+      "kb_used": "3209684",
+      "kb_available": "43668216",
+      "percent_used": "7%",
+      "mount": "/",
+      "total_inodes": "3145728",
+      "inodes_used": "356466",
+      "inodes_available": "2789262",
+      "inodes_percent_used": "12%",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "noatime",
+        "data=ordered"
+      ],
+      "uuid": "5574b18c-a6c2-4b01-ad08-4b5811d3cc0a"
+    },
+    "devtmpfs": {
+      "kb_size": "10240",
+      "kb_used": "0",
+      "kb_available": "10240",
+      "percent_used": "0%",
+      "mount": "/dev",
+      "total_inodes": "94611",
+      "inodes_used": "360",
+      "inodes_available": "94251",
+      "inodes_percent_used": "1%",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "relatime",
+        "size=10240k",
+        "nr_inodes=94611",
+        "mode=755"
+      ]
+    },
+    "tmpfs": {
+      "kb_size": "75948",
+      "kb_used": "248",
+      "kb_available": "75700",
+      "percent_used": "1%",
+      "mount": "/run",
+      "total_inodes": "94934",
+      "inodes_used": "295",
+      "inodes_available": "94639",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nodev",
+        "relatime",
+        "size=75948k",
+        "mode=755"
+      ]
+    },
+    "shm": {
+      "kb_size": "379736",
+      "kb_used": "0",
+      "kb_available": "379736",
+      "percent_used": "0%",
+      "mount": "/dev/shm",
+      "total_inodes": "94934",
+      "inodes_used": "1",
+      "inodes_available": "94933",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "cgroup_root": {
+      "kb_size": "10240",
+      "kb_used": "0",
+      "kb_available": "10240",
+      "percent_used": "0%",
+      "mount": "/sys/fs/cgroup",
+      "total_inodes": "94934",
+      "inodes_used": "6",
+      "inodes_available": "94928",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "size=10240k",
+        "mode=755"
+      ]
+    },
+    "rootfs": {
+      "mount": "/",
+      "fs_type": "rootfs",
+      "mount_options": [
+        "rw"
+      ]
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "mqueue": {
+      "mount": "/dev/mqueue",
+      "fs_type": "mqueue",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620"
+      ]
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "openrc": {
+      "mount": "/sys/fs/cgroup/openrc",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "release_agent=/lib64/rc/sh/cgroup-release-agent.sh",
+        "name=openrc"
+      ]
+    },
+    "cpuset": {
+      "mount": "/sys/fs/cgroup/cpuset",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "cpuset"
+      ]
+    },
+    "cpu": {
+      "mount": "/sys/fs/cgroup/cpu",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "cpu"
+      ]
+    },
+    "cpuacct": {
+      "mount": "/sys/fs/cgroup/cpuacct",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "cpuacct"
+      ]
+    },
+    "freezer": {
+      "mount": "/sys/fs/cgroup/freezer",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "freezer"
+      ]
+    },
+    "binfmt_misc": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "binfmt_misc",
+      "mount_options": [
+        "rw",
+        "nodev",
+        "noexec",
+        "nosuid"
+      ]
+    },
+    "selinuxfs": {
+      "mount": "/sys/fs/selinux",
+      "fs_type": "selinuxfs",
+      "mount_options": [
+        "rw"
+      ]
+    },
+    "/dev/sda2": {
+      "fs_type": "swap",
+      "uuid": "b806df0c-7367-41b7-b99c-507b52ddf033"
+    }
+  },
+  "init_package": "init",
+  "root_group": "root",
+  "languages": {
+    "ruby": {
+      "platform": "x86_64-linux",
+      "version": "2.3.1",
+      "release_date": "2016-04-26",
+      "target": "x86_64-pc-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "pc",
+      "target_os": "linux",
+      "host": "x86_64-pc-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux-gnu",
+      "host_vendor": "pc",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gems_dir": "/usr/local/gems",
+      "gem_bin": "/usr/local/bin/gem"
+    },
+    "powershell": null
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "12.10.24",
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.10.24/lib"
+    },
+    "ohai": {
+      "version": "8.16.0",
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.16.0/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "settings": {
+    },
+    "interfaces": {
+      "eth0": {
+        "addresses": {
+          "10.0.0.2": {
+            "broadcast": "10.0.0.255",
+            "family": "inet",
+            "netmask": "255.255.255.0",
+            "prefixlen": "23",
+            "scope": "Global"
+          }
+        },
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "encapsulation": "Ethernet",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "1500",
+        "number": "0",
+        "routes": {
+          "10.0.0.0/255": {
+            "scope": "link",
+            "src": "10.0.0.2"
+          }
+        },
+        "state": "up",
+        "type": "eth"
+      }
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "cpu": {
+    "real": 1,
+    "total": 1,
+    "cores": 1
+  },
+  "memory": {
+    "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
+  }
+}


### PR DESCRIPTION
This is a 2015 image of Gentoo with the latest Ruby/Chef. It basically allows someone testing on Gentoo to get all the new Ohai magic

Note: Chef version detection of Gentoo is bogus. I'm going to fix that in Ohai. 2.2 means nothing in Gentoo land. It's the base image that was used to bootstrap the distro.