### PR TITLE
Release 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Fauxhai Changelog
 
+## v3.5.0
+- Fauxhai now requires at least Ruby 2.0
+- Added CentOS 6.8, Arch 4.5.4-1-ARCH, Debian 7.10, Gentoo 2.2
+- Fixed the naming and bad JSON in Amazon 2016.03
+- Updated the raw Github URL to Github's recommended URL
+- Fixed the Rake task to properly fail if JSON files fail to validate
+
 ## v3.4.0
 - Added Ubuntu 16.04, Debian 8.4, FreeBSD 10.3, and OmniOS r151018
 

--- a/lib/fauxhai/version.rb
+++ b/lib/fauxhai/version.rb
@@ -1,3 +1,3 @@
 module Fauxhai
-  VERSION = '3.4.0'
+  VERSION = '3.5.0'
 end


### PR DESCRIPTION
We're dropping Ruby 1.9 support with this release, but I chose not to bump to 4.0 since we already require Ruby 2.1 in ChefSpec and that is the only gem that depends on Fauxhai.