### PR TITLE
Update root_group on FreeBSD platforms to be 'wheel'

### DIFF
--- a/lib/fauxhai/platforms/freebsd/10.0.json
+++ b/lib/fauxhai/platforms/freebsd/10.0.json
@@ -190,6 +190,7 @@
     }
   },
   "ohai_time": 1397572956.9009218,
+  "root_group": "wheel",
   "languages": {
     "ruby": {
       "platform": "amd64-freebsd10",

--- a/lib/fauxhai/platforms/freebsd/10.1.json
+++ b/lib/fauxhai/platforms/freebsd/10.1.json
@@ -187,6 +187,7 @@
     "ps": "ps -ax"
   },
   "ohai_time": 1445868863.204265,
+  "root_group": "wheel",
   "languages": {
     "ruby": {
       "bin_dir": "/usr/local/bin",

--- a/lib/fauxhai/platforms/freebsd/10.2.json
+++ b/lib/fauxhai/platforms/freebsd/10.2.json
@@ -187,6 +187,7 @@
     }
   },
   "ohai_time": 1445813955.465053,
+  "root_group": "wheel",
   "languages": {
     "ruby": {
       "bin_dir": "/usr/local/bin",

--- a/lib/fauxhai/platforms/freebsd/8.4.json
+++ b/lib/fauxhai/platforms/freebsd/8.4.json
@@ -225,6 +225,7 @@
     }
   },
   "ohai_time": 1397572941.8629289,
+  "root_group": "wheel",
   "languages": {
     "ruby": {
       "platform": "amd64-freebsd8",

--- a/lib/fauxhai/platforms/freebsd/9.1.json
+++ b/lib/fauxhai/platforms/freebsd/9.1.json
@@ -187,6 +187,7 @@
     "ps": "ps -ax"
   },
   "ohai_time": 1445869518.257994,
+  "root_group": "wheel",
   "languages": {
     "ruby": {
       "bin_dir": "/usr/local/bin",

--- a/lib/fauxhai/platforms/freebsd/9.2.json
+++ b/lib/fauxhai/platforms/freebsd/9.2.json
@@ -187,6 +187,7 @@
     "ps": "ps -ax"
   },
   "ohai_time": 1445869556.814468,
+  "root_group": "wheel",
   "languages": {
     "ruby": {
       "bin_dir": "/usr/local/bin",

--- a/lib/fauxhai/platforms/freebsd/9.3.json
+++ b/lib/fauxhai/platforms/freebsd/9.3.json
@@ -187,6 +187,7 @@
     "ps": "ps -ax"
   },
   "ohai_time": 1445857062.2875056,
+  "root_group": "wheel",
   "languages": {
     "ruby": {
       "bin_dir": "/usr/local/bin",


### PR DESCRIPTION
`root_group` wasn't set on any of the versions other than 10.3. This commit fixes the issue.