### PR TITLE
Fix network ohai in all generated json files

### DIFF
--- a/lib/fauxhai/platforms/aix/6.1.json
+++ b/lib/fauxhai/platforms/aix/6.1.json
@@ -702,12 +702,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/aix/6.1.json
+++ b/lib/fauxhai/platforms/aix/6.1.json
@@ -686,7 +686,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/aix/7.1.json
+++ b/lib/fauxhai/platforms/aix/7.1.json
@@ -554,7 +554,6 @@
     "ps": "ps -ef"
   },
   "dmi": {
-
   },
   "ohai_time": 1412030480.531248,
   "languages": {
@@ -638,7 +637,6 @@
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
     "settings": {
-
     },
     "interfaces": {
       "eth0": {
@@ -663,12 +661,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/aix/7.1.json
+++ b/lib/fauxhai/platforms/aix/7.1.json
@@ -647,7 +647,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/amazon/2012.09.json
+++ b/lib/fauxhai/platforms/amazon/2012.09.json
@@ -227,7 +227,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/amazon/2012.09.json
+++ b/lib/fauxhai/platforms/amazon/2012.09.json
@@ -243,12 +243,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/amazon/2013.09.json
+++ b/lib/fauxhai/platforms/amazon/2013.09.json
@@ -300,12 +300,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/amazon/2013.09.json
+++ b/lib/fauxhai/platforms/amazon/2013.09.json
@@ -284,7 +284,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/amazon/2014.03.json
+++ b/lib/fauxhai/platforms/amazon/2014.03.json
@@ -347,7 +347,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/amazon/2014.03.json
+++ b/lib/fauxhai/platforms/amazon/2014.03.json
@@ -363,12 +363,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/amazon/2014.09.json
+++ b/lib/fauxhai/platforms/amazon/2014.09.json
@@ -280,12 +280,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/amazon/2014.09.json
+++ b/lib/fauxhai/platforms/amazon/2014.09.json
@@ -264,7 +264,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/amazon/2015.03.json
+++ b/lib/fauxhai/platforms/amazon/2015.03.json
@@ -280,12 +280,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/amazon/2015.03.json
+++ b/lib/fauxhai/platforms/amazon/2015.03.json
@@ -264,7 +264,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/amazon/2015.09.json
+++ b/lib/fauxhai/platforms/amazon/2015.09.json
@@ -312,12 +312,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/amazon/2015.09.json
+++ b/lib/fauxhai/platforms/amazon/2015.09.json
@@ -296,7 +296,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/amazon/2016.03.json
+++ b/lib/fauxhai/platforms/amazon/2016.03.json
@@ -304,12 +304,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/amazon/2016.03.json
+++ b/lib/fauxhai/platforms/amazon/2016.03.json
@@ -288,7 +288,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/arch/3.10.5-1-ARCH.json
+++ b/lib/fauxhai/platforms/arch/3.10.5-1-ARCH.json
@@ -483,7 +483,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/arch/3.10.5-1-ARCH.json
+++ b/lib/fauxhai/platforms/arch/3.10.5-1-ARCH.json
@@ -3,7 +3,6 @@
     "ps": "ps -ef"
   },
   "dmi": {
-
   },
   "kernel": {
     "name": "Linux",
@@ -155,7 +154,6 @@
     }
   },
   "lsb": {
-
   },
   "os": "linux",
   "os_version": "3.10.5-1-ARCH",
@@ -474,7 +472,6 @@
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
     "settings": {
-
     },
     "interfaces": {
       "eth0": {
@@ -499,12 +496,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/arch/4.5.4-1-ARCH.json
+++ b/lib/fauxhai/platforms/arch/4.5.4-1-ARCH.json
@@ -647,12 +647,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/arch/4.5.4-1-ARCH.json
+++ b/lib/fauxhai/platforms/arch/4.5.4-1-ARCH.json
@@ -631,7 +631,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.0.json
+++ b/lib/fauxhai/platforms/centos/5.0.json
@@ -688,12 +688,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.0.json
+++ b/lib/fauxhai/platforms/centos/5.0.json
@@ -672,7 +672,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.1.json
+++ b/lib/fauxhai/platforms/centos/5.1.json
@@ -692,7 +692,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.1.json
+++ b/lib/fauxhai/platforms/centos/5.1.json
@@ -708,12 +708,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.10.json
+++ b/lib/fauxhai/platforms/centos/5.10.json
@@ -860,12 +860,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.10.json
+++ b/lib/fauxhai/platforms/centos/5.10.json
@@ -844,7 +844,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.11.json
+++ b/lib/fauxhai/platforms/centos/5.11.json
@@ -726,12 +726,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.11.json
+++ b/lib/fauxhai/platforms/centos/5.11.json
@@ -710,7 +710,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.2.json
+++ b/lib/fauxhai/platforms/centos/5.2.json
@@ -704,7 +704,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.2.json
+++ b/lib/fauxhai/platforms/centos/5.2.json
@@ -720,12 +720,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.3.json
+++ b/lib/fauxhai/platforms/centos/5.3.json
@@ -732,7 +732,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.3.json
+++ b/lib/fauxhai/platforms/centos/5.3.json
@@ -748,12 +748,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.4.json
+++ b/lib/fauxhai/platforms/centos/5.4.json
@@ -752,12 +752,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.4.json
+++ b/lib/fauxhai/platforms/centos/5.4.json
@@ -736,7 +736,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.5.json
+++ b/lib/fauxhai/platforms/centos/5.5.json
@@ -768,12 +768,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.5.json
+++ b/lib/fauxhai/platforms/centos/5.5.json
@@ -752,7 +752,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.6.json
+++ b/lib/fauxhai/platforms/centos/5.6.json
@@ -836,7 +836,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.6.json
+++ b/lib/fauxhai/platforms/centos/5.6.json
@@ -852,12 +852,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.7.json
+++ b/lib/fauxhai/platforms/centos/5.7.json
@@ -856,12 +856,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.7.json
+++ b/lib/fauxhai/platforms/centos/5.7.json
@@ -840,7 +840,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.8.json
+++ b/lib/fauxhai/platforms/centos/5.8.json
@@ -860,12 +860,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.8.json
+++ b/lib/fauxhai/platforms/centos/5.8.json
@@ -844,7 +844,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/5.9.json
+++ b/lib/fauxhai/platforms/centos/5.9.json
@@ -860,12 +860,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/5.9.json
+++ b/lib/fauxhai/platforms/centos/5.9.json
@@ -844,7 +844,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/6.0.json
+++ b/lib/fauxhai/platforms/centos/6.0.json
@@ -613,12 +613,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/6.0.json
+++ b/lib/fauxhai/platforms/centos/6.0.json
@@ -597,7 +597,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/6.1.json
+++ b/lib/fauxhai/platforms/centos/6.1.json
@@ -595,7 +595,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/6.1.json
+++ b/lib/fauxhai/platforms/centos/6.1.json
@@ -611,12 +611,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/6.2.json
+++ b/lib/fauxhai/platforms/centos/6.2.json
@@ -595,7 +595,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/6.2.json
+++ b/lib/fauxhai/platforms/centos/6.2.json
@@ -611,12 +611,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/6.3.json
+++ b/lib/fauxhai/platforms/centos/6.3.json
@@ -591,7 +591,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/6.3.json
+++ b/lib/fauxhai/platforms/centos/6.3.json
@@ -607,12 +607,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/6.4.json
+++ b/lib/fauxhai/platforms/centos/6.4.json
@@ -600,12 +600,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/6.4.json
+++ b/lib/fauxhai/platforms/centos/6.4.json
@@ -584,7 +584,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/6.5.json
+++ b/lib/fauxhai/platforms/centos/6.5.json
@@ -573,7 +573,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/6.5.json
+++ b/lib/fauxhai/platforms/centos/6.5.json
@@ -589,12 +589,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/6.6.json
+++ b/lib/fauxhai/platforms/centos/6.6.json
@@ -573,7 +573,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/6.6.json
+++ b/lib/fauxhai/platforms/centos/6.6.json
@@ -589,12 +589,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/6.7.json
+++ b/lib/fauxhai/platforms/centos/6.7.json
@@ -577,7 +577,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/6.7.json
+++ b/lib/fauxhai/platforms/centos/6.7.json
@@ -593,12 +593,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/6.8.json
+++ b/lib/fauxhai/platforms/centos/6.8.json
@@ -575,7 +575,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/6.8.json
+++ b/lib/fauxhai/platforms/centos/6.8.json
@@ -591,12 +591,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/7.0.1406.json
+++ b/lib/fauxhai/platforms/centos/7.0.1406.json
@@ -777,7 +777,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/7.0.1406.json
+++ b/lib/fauxhai/platforms/centos/7.0.1406.json
@@ -793,12 +793,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/7.0.json
+++ b/lib/fauxhai/platforms/centos/7.0.json
@@ -777,7 +777,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/7.0.json
+++ b/lib/fauxhai/platforms/centos/7.0.json
@@ -793,12 +793,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/7.1.1503.json
+++ b/lib/fauxhai/platforms/centos/7.1.1503.json
@@ -777,7 +777,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/7.1.1503.json
+++ b/lib/fauxhai/platforms/centos/7.1.1503.json
@@ -793,12 +793,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/centos/7.2.1511.json
+++ b/lib/fauxhai/platforms/centos/7.2.1511.json
@@ -666,7 +666,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/centos/7.2.1511.json
+++ b/lib/fauxhai/platforms/centos/7.2.1511.json
@@ -682,12 +682,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/6.0.5.json
+++ b/lib/fauxhai/platforms/debian/6.0.5.json
@@ -258,7 +258,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -282,12 +283,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/6.0.5.json
+++ b/lib/fauxhai/platforms/debian/6.0.5.json
@@ -266,7 +266,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/7.0.json
+++ b/lib/fauxhai/platforms/debian/7.0.json
@@ -563,7 +563,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -587,12 +588,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/7.0.json
+++ b/lib/fauxhai/platforms/debian/7.0.json
@@ -571,7 +571,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/7.1.json
+++ b/lib/fauxhai/platforms/debian/7.1.json
@@ -563,7 +563,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -587,16 +588,18 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }
-
     }
   },
   "uptime": "30 days 15 hours 07 minutes 30 seconds",

--- a/lib/fauxhai/platforms/debian/7.1.json
+++ b/lib/fauxhai/platforms/debian/7.1.json
@@ -571,7 +571,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/7.10.json
+++ b/lib/fauxhai/platforms/debian/7.10.json
@@ -618,12 +618,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/7.10.json
+++ b/lib/fauxhai/platforms/debian/7.10.json
@@ -602,7 +602,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/7.2.json
+++ b/lib/fauxhai/platforms/debian/7.2.json
@@ -372,12 +372,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/7.2.json
+++ b/lib/fauxhai/platforms/debian/7.2.json
@@ -356,7 +356,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/7.4.json
+++ b/lib/fauxhai/platforms/debian/7.4.json
@@ -407,12 +407,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/7.4.json
+++ b/lib/fauxhai/platforms/debian/7.4.json
@@ -391,7 +391,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/7.5.json
+++ b/lib/fauxhai/platforms/debian/7.5.json
@@ -2643,7 +2643,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/7.5.json
+++ b/lib/fauxhai/platforms/debian/7.5.json
@@ -2659,12 +2659,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/7.6.json
+++ b/lib/fauxhai/platforms/debian/7.6.json
@@ -570,12 +570,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/7.6.json
+++ b/lib/fauxhai/platforms/debian/7.6.json
@@ -554,7 +554,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/7.7.json
+++ b/lib/fauxhai/platforms/debian/7.7.json
@@ -613,12 +613,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/7.7.json
+++ b/lib/fauxhai/platforms/debian/7.7.json
@@ -597,7 +597,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/7.8.json
+++ b/lib/fauxhai/platforms/debian/7.8.json
@@ -613,12 +613,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/7.8.json
+++ b/lib/fauxhai/platforms/debian/7.8.json
@@ -597,7 +597,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/7.9.json
+++ b/lib/fauxhai/platforms/debian/7.9.json
@@ -652,12 +652,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/7.9.json
+++ b/lib/fauxhai/platforms/debian/7.9.json
@@ -636,7 +636,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/8.0.json
+++ b/lib/fauxhai/platforms/debian/8.0.json
@@ -643,7 +643,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/8.0.json
+++ b/lib/fauxhai/platforms/debian/8.0.json
@@ -659,12 +659,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/8.1.json
+++ b/lib/fauxhai/platforms/debian/8.1.json
@@ -643,7 +643,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/8.1.json
+++ b/lib/fauxhai/platforms/debian/8.1.json
@@ -659,12 +659,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/8.2.json
+++ b/lib/fauxhai/platforms/debian/8.2.json
@@ -759,12 +759,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/8.2.json
+++ b/lib/fauxhai/platforms/debian/8.2.json
@@ -743,7 +743,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/8.4.json
+++ b/lib/fauxhai/platforms/debian/8.4.json
@@ -764,12 +764,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/8.4.json
+++ b/lib/fauxhai/platforms/debian/8.4.json
@@ -748,7 +748,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/jessie/sid.json
+++ b/lib/fauxhai/platforms/debian/jessie/sid.json
@@ -545,7 +545,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/jessie/sid.json
+++ b/lib/fauxhai/platforms/debian/jessie/sid.json
@@ -561,12 +561,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/debian/stretch/sid.json
+++ b/lib/fauxhai/platforms/debian/stretch/sid.json
@@ -573,7 +573,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/debian/stretch/sid.json
+++ b/lib/fauxhai/platforms/debian/stretch/sid.json
@@ -589,12 +589,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/dragonfly4/4.2-RELEASE.json
+++ b/lib/fauxhai/platforms/dragonfly4/4.2-RELEASE.json
@@ -132,12 +132,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/dragonfly4/4.2-RELEASE.json
+++ b/lib/fauxhai/platforms/dragonfly4/4.2-RELEASE.json
@@ -116,7 +116,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/fedora/18.json
+++ b/lib/fauxhai/platforms/fedora/18.json
@@ -443,12 +443,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/fedora/18.json
+++ b/lib/fauxhai/platforms/fedora/18.json
@@ -427,7 +427,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/fedora/19.json
+++ b/lib/fauxhai/platforms/fedora/19.json
@@ -443,12 +443,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/fedora/19.json
+++ b/lib/fauxhai/platforms/fedora/19.json
@@ -427,7 +427,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/fedora/20.json
+++ b/lib/fauxhai/platforms/fedora/20.json
@@ -395,7 +395,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/fedora/20.json
+++ b/lib/fauxhai/platforms/fedora/20.json
@@ -411,12 +411,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/fedora/21.json
+++ b/lib/fauxhai/platforms/fedora/21.json
@@ -671,7 +671,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/fedora/21.json
+++ b/lib/fauxhai/platforms/fedora/21.json
@@ -687,12 +687,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/fedora/22.json
+++ b/lib/fauxhai/platforms/fedora/22.json
@@ -731,12 +731,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/fedora/22.json
+++ b/lib/fauxhai/platforms/fedora/22.json
@@ -715,7 +715,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/fedora/23.json
+++ b/lib/fauxhai/platforms/fedora/23.json
@@ -719,7 +719,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/fedora/23.json
+++ b/lib/fauxhai/platforms/fedora/23.json
@@ -735,12 +735,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/freebsd/10.0.json
+++ b/lib/fauxhai/platforms/freebsd/10.0.json
@@ -291,7 +291,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/freebsd/10.0.json
+++ b/lib/fauxhai/platforms/freebsd/10.0.json
@@ -307,12 +307,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/freebsd/10.1.json
+++ b/lib/fauxhai/platforms/freebsd/10.1.json
@@ -278,7 +278,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/freebsd/10.1.json
+++ b/lib/fauxhai/platforms/freebsd/10.1.json
@@ -294,12 +294,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/freebsd/10.2.json
+++ b/lib/fauxhai/platforms/freebsd/10.2.json
@@ -278,7 +278,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/freebsd/10.2.json
+++ b/lib/fauxhai/platforms/freebsd/10.2.json
@@ -294,12 +294,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/freebsd/10.3.json
+++ b/lib/fauxhai/platforms/freebsd/10.3.json
@@ -303,12 +303,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/freebsd/10.3.json
+++ b/lib/fauxhai/platforms/freebsd/10.3.json
@@ -287,7 +287,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/freebsd/8.4.json
+++ b/lib/fauxhai/platforms/freebsd/8.4.json
@@ -326,7 +326,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/freebsd/8.4.json
+++ b/lib/fauxhai/platforms/freebsd/8.4.json
@@ -342,12 +342,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/freebsd/9.1.json
+++ b/lib/fauxhai/platforms/freebsd/9.1.json
@@ -278,7 +278,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/freebsd/9.1.json
+++ b/lib/fauxhai/platforms/freebsd/9.1.json
@@ -294,12 +294,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/freebsd/9.2.json
+++ b/lib/fauxhai/platforms/freebsd/9.2.json
@@ -278,7 +278,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/freebsd/9.2.json
+++ b/lib/fauxhai/platforms/freebsd/9.2.json
@@ -294,12 +294,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/freebsd/9.3.json
+++ b/lib/fauxhai/platforms/freebsd/9.3.json
@@ -278,7 +278,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/freebsd/9.3.json
+++ b/lib/fauxhai/platforms/freebsd/9.3.json
@@ -294,12 +294,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/gentoo/2.1.json
+++ b/lib/fauxhai/platforms/gentoo/2.1.json
@@ -372,7 +372,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -396,12 +397,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/gentoo/2.1.json
+++ b/lib/fauxhai/platforms/gentoo/2.1.json
@@ -380,7 +380,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/gentoo/2.2.json
+++ b/lib/fauxhai/platforms/gentoo/2.2.json
@@ -385,12 +385,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/gentoo/2.2.json
+++ b/lib/fauxhai/platforms/gentoo/2.2.json
@@ -369,7 +369,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/ios_xr/6.0.0.14I.json
+++ b/lib/fauxhai/platforms/ios_xr/6.0.0.14I.json
@@ -319,12 +319,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ios_xr/6.0.0.14I.json
+++ b/lib/fauxhai/platforms/ios_xr/6.0.0.14I.json
@@ -303,7 +303,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/mac_os_x/10.10.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.10.json
@@ -819,7 +819,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/mac_os_x/10.10.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.10.json
@@ -715,7 +715,6 @@
     "ps": "ps -ef"
   },
   "dmi": {
-
   },
   "ohai_time": 1414047561.936486,
   "languages": {
@@ -810,7 +809,6 @@
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
     "settings": {
-
     },
     "interfaces": {
       "eth0": {
@@ -835,12 +833,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/mac_os_x/10.11.1.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.11.1.json
@@ -836,12 +836,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/mac_os_x/10.11.1.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.11.1.json
@@ -820,7 +820,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/mac_os_x/10.6.8.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.6.8.json
@@ -812,7 +812,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/mac_os_x/10.6.8.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.6.8.json
@@ -804,7 +804,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -828,12 +829,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/mac_os_x/10.7.4.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.7.4.json
@@ -764,7 +764,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/mac_os_x/10.7.4.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.7.4.json
@@ -756,7 +756,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -780,12 +781,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/mac_os_x/10.8.2.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.8.2.json
@@ -713,7 +713,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -737,12 +738,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/mac_os_x/10.8.2.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.8.2.json
@@ -721,7 +721,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/mac_os_x/10.9.2.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.9.2.json
@@ -766,7 +766,7 @@
           "broadcast": "10.0.0.255",
           "family": "inet",
           "netmask": "255.255.255.0",
-          "prefixlen": "23",
+          "prefixlen": "24",
           "scope": "Global"
         }
       },

--- a/lib/fauxhai/platforms/mac_os_x/10.9.2.json
+++ b/lib/fauxhai/platforms/mac_os_x/10.9.2.json
@@ -782,12 +782,15 @@
       ],
       "mtu": "1500",
       "number": "0",
-      "routes": {
-        "10.0.0.0/255": {
+      "routes": [
+        {
+          "destination": "10.0.0.0/24",
+          "family": "inet",
           "scope": "link",
+          "proto": "kernel",
           "src": "10.0.0.2"
         }
-      },
+      ],
       "state": "up",
       "type": "eth"
     }

--- a/lib/fauxhai/platforms/nexus/5.json
+++ b/lib/fauxhai/platforms/nexus/5.json
@@ -261,7 +261,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/nexus/5.json
+++ b/lib/fauxhai/platforms/nexus/5.json
@@ -277,12 +277,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/omnios/151002.json
+++ b/lib/fauxhai/platforms/omnios/151002.json
@@ -2346,7 +2346,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/omnios/151002.json
+++ b/lib/fauxhai/platforms/omnios/151002.json
@@ -2338,7 +2338,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -2362,12 +2363,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/omnios/151006.json
+++ b/lib/fauxhai/platforms/omnios/151006.json
@@ -1928,12 +1928,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/omnios/151006.json
+++ b/lib/fauxhai/platforms/omnios/151006.json
@@ -1912,7 +1912,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/omnios/151008.json
+++ b/lib/fauxhai/platforms/omnios/151008.json
@@ -2203,12 +2203,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/omnios/151008.json
+++ b/lib/fauxhai/platforms/omnios/151008.json
@@ -2187,7 +2187,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/omnios/151014.json
+++ b/lib/fauxhai/platforms/omnios/151014.json
@@ -2399,12 +2399,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/omnios/151014.json
+++ b/lib/fauxhai/platforms/omnios/151014.json
@@ -2383,7 +2383,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/omnios/151018.json
+++ b/lib/fauxhai/platforms/omnios/151018.json
@@ -2313,7 +2313,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/omnios/151018.json
+++ b/lib/fauxhai/platforms/omnios/151018.json
@@ -2329,12 +2329,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/openbsd/5.4.json
+++ b/lib/fauxhai/platforms/openbsd/5.4.json
@@ -192,7 +192,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/openbsd/5.4.json
+++ b/lib/fauxhai/platforms/openbsd/5.4.json
@@ -208,12 +208,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/opensuse/12.3.json
+++ b/lib/fauxhai/platforms/opensuse/12.3.json
@@ -575,7 +575,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/opensuse/12.3.json
+++ b/lib/fauxhai/platforms/opensuse/12.3.json
@@ -591,12 +591,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/opensuse/13.1.json
+++ b/lib/fauxhai/platforms/opensuse/13.1.json
@@ -542,12 +542,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/opensuse/13.1.json
+++ b/lib/fauxhai/platforms/opensuse/13.1.json
@@ -526,7 +526,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/opensuse/13.2.json
+++ b/lib/fauxhai/platforms/opensuse/13.2.json
@@ -624,12 +624,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/opensuse/13.2.json
+++ b/lib/fauxhai/platforms/opensuse/13.2.json
@@ -608,7 +608,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/opensuse/42.1.json
+++ b/lib/fauxhai/platforms/opensuse/42.1.json
@@ -522,12 +522,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/opensuse/42.1.json
+++ b/lib/fauxhai/platforms/opensuse/42.1.json
@@ -506,7 +506,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/oracle/5.10.json
+++ b/lib/fauxhai/platforms/oracle/5.10.json
@@ -127,12 +127,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/oracle/5.10.json
+++ b/lib/fauxhai/platforms/oracle/5.10.json
@@ -111,7 +111,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/oracle/6.5.json
+++ b/lib/fauxhai/platforms/oracle/6.5.json
@@ -326,12 +326,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/oracle/6.5.json
+++ b/lib/fauxhai/platforms/oracle/6.5.json
@@ -310,7 +310,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/oracle/6.6.json
+++ b/lib/fauxhai/platforms/oracle/6.6.json
@@ -355,12 +355,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/oracle/6.6.json
+++ b/lib/fauxhai/platforms/oracle/6.6.json
@@ -339,7 +339,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/oracle/7.0.json
+++ b/lib/fauxhai/platforms/oracle/7.0.json
@@ -605,12 +605,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/oracle/7.0.json
+++ b/lib/fauxhai/platforms/oracle/7.0.json
@@ -589,7 +589,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/oracle/7.1.json
+++ b/lib/fauxhai/platforms/oracle/7.1.json
@@ -783,7 +783,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/oracle/7.1.json
+++ b/lib/fauxhai/platforms/oracle/7.1.json
@@ -799,12 +799,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/5.10.json
+++ b/lib/fauxhai/platforms/redhat/5.10.json
@@ -2756,7 +2756,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/5.10.json
+++ b/lib/fauxhai/platforms/redhat/5.10.json
@@ -2772,12 +2772,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/5.6.json
+++ b/lib/fauxhai/platforms/redhat/5.6.json
@@ -2840,12 +2840,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/5.6.json
+++ b/lib/fauxhai/platforms/redhat/5.6.json
@@ -2824,7 +2824,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/5.7.json
+++ b/lib/fauxhai/platforms/redhat/5.7.json
@@ -2927,7 +2927,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/5.7.json
+++ b/lib/fauxhai/platforms/redhat/5.7.json
@@ -2943,12 +2943,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/5.8.json
+++ b/lib/fauxhai/platforms/redhat/5.8.json
@@ -1497,7 +1497,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -1521,12 +1522,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/5.8.json
+++ b/lib/fauxhai/platforms/redhat/5.8.json
@@ -1505,7 +1505,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/5.9.json
+++ b/lib/fauxhai/platforms/redhat/5.9.json
@@ -2756,7 +2756,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/5.9.json
+++ b/lib/fauxhai/platforms/redhat/5.9.json
@@ -2772,12 +2772,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/6.0.json
+++ b/lib/fauxhai/platforms/redhat/6.0.json
@@ -2489,7 +2489,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/6.0.json
+++ b/lib/fauxhai/platforms/redhat/6.0.json
@@ -2505,12 +2505,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/6.1.json
+++ b/lib/fauxhai/platforms/redhat/6.1.json
@@ -2509,12 +2509,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/6.1.json
+++ b/lib/fauxhai/platforms/redhat/6.1.json
@@ -2493,7 +2493,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/6.2.json
+++ b/lib/fauxhai/platforms/redhat/6.2.json
@@ -2560,7 +2560,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/6.2.json
+++ b/lib/fauxhai/platforms/redhat/6.2.json
@@ -2576,12 +2576,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/6.3.json
+++ b/lib/fauxhai/platforms/redhat/6.3.json
@@ -2474,7 +2474,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/6.3.json
+++ b/lib/fauxhai/platforms/redhat/6.3.json
@@ -2490,12 +2490,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/6.4.json
+++ b/lib/fauxhai/platforms/redhat/6.4.json
@@ -301,12 +301,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/6.4.json
+++ b/lib/fauxhai/platforms/redhat/6.4.json
@@ -285,7 +285,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/6.5.json
+++ b/lib/fauxhai/platforms/redhat/6.5.json
@@ -301,12 +301,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/6.5.json
+++ b/lib/fauxhai/platforms/redhat/6.5.json
@@ -285,7 +285,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/6.6.json
+++ b/lib/fauxhai/platforms/redhat/6.6.json
@@ -497,12 +497,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/6.6.json
+++ b/lib/fauxhai/platforms/redhat/6.6.json
@@ -481,7 +481,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/7.0.json
+++ b/lib/fauxhai/platforms/redhat/7.0.json
@@ -828,12 +828,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/redhat/7.0.json
+++ b/lib/fauxhai/platforms/redhat/7.0.json
@@ -812,7 +812,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/7.1.json
+++ b/lib/fauxhai/platforms/redhat/7.1.json
@@ -708,7 +708,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/redhat/7.1.json
+++ b/lib/fauxhai/platforms/redhat/7.1.json
@@ -724,12 +724,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/slackware/14.1.json
+++ b/lib/fauxhai/platforms/slackware/14.1.json
@@ -219,13 +219,11 @@
   "os": "linux",
   "os_version": "3.10.17",
   "lsb": {
-
   },
   "platform": "slackware",
   "platform_version": "14.1",
   "platform_family": "slackware",
   "dmi": {
-
   },
   "command": {
     "ps": "ps -ef"
@@ -323,7 +321,6 @@
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
     "settings": {
-
     },
     "interfaces": {
       "eth0": {
@@ -348,12 +345,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/slackware/14.1.json
+++ b/lib/fauxhai/platforms/slackware/14.1.json
@@ -332,7 +332,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/smartos/5.11.json
+++ b/lib/fauxhai/platforms/smartos/5.11.json
@@ -1636,7 +1636,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/smartos/5.11.json
+++ b/lib/fauxhai/platforms/smartos/5.11.json
@@ -1652,12 +1652,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/smartos/joyent_20130111T180733Z.json
+++ b/lib/fauxhai/platforms/smartos/joyent_20130111T180733Z.json
@@ -1605,7 +1605,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "net0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "net0": {
         "addresses": {
@@ -1630,12 +1631,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "net"
       }

--- a/lib/fauxhai/platforms/solaris2/5.10.json
+++ b/lib/fauxhai/platforms/solaris2/5.10.json
@@ -2424,12 +2424,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/solaris2/5.10.json
+++ b/lib/fauxhai/platforms/solaris2/5.10.json
@@ -2408,7 +2408,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/solaris2/5.11.json
+++ b/lib/fauxhai/platforms/solaris2/5.11.json
@@ -3538,12 +3538,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/solaris2/5.11.json
+++ b/lib/fauxhai/platforms/solaris2/5.11.json
@@ -3522,7 +3522,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/suse/11.1.json
+++ b/lib/fauxhai/platforms/suse/11.1.json
@@ -2536,12 +2536,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/suse/11.1.json
+++ b/lib/fauxhai/platforms/suse/11.1.json
@@ -2520,7 +2520,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/suse/11.2.json
+++ b/lib/fauxhai/platforms/suse/11.2.json
@@ -2537,12 +2537,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/suse/11.2.json
+++ b/lib/fauxhai/platforms/suse/11.2.json
@@ -2521,7 +2521,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/suse/11.3.json
+++ b/lib/fauxhai/platforms/suse/11.3.json
@@ -2498,12 +2498,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/suse/11.3.json
+++ b/lib/fauxhai/platforms/suse/11.3.json
@@ -2482,7 +2482,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/suse/12.0.json
+++ b/lib/fauxhai/platforms/suse/12.0.json
@@ -666,7 +666,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/suse/12.0.json
+++ b/lib/fauxhai/platforms/suse/12.0.json
@@ -682,12 +682,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ubuntu/10.04.json
+++ b/lib/fauxhai/platforms/ubuntu/10.04.json
@@ -478,7 +478,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -502,12 +503,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ubuntu/10.04.json
+++ b/lib/fauxhai/platforms/ubuntu/10.04.json
@@ -486,7 +486,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/ubuntu/12.04.json
+++ b/lib/fauxhai/platforms/ubuntu/12.04.json
@@ -467,7 +467,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/ubuntu/12.04.json
+++ b/lib/fauxhai/platforms/ubuntu/12.04.json
@@ -483,12 +483,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ubuntu/13.04.json
+++ b/lib/fauxhai/platforms/ubuntu/13.04.json
@@ -2548,7 +2548,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/ubuntu/13.04.json
+++ b/lib/fauxhai/platforms/ubuntu/13.04.json
@@ -2540,7 +2540,8 @@
   "network": {
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
-    "settings": {},
+    "settings": {
+    },
     "interfaces": {
       "eth0": {
         "addresses": {
@@ -2564,12 +2565,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ubuntu/13.10.json
+++ b/lib/fauxhai/platforms/ubuntu/13.10.json
@@ -467,7 +467,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/ubuntu/13.10.json
+++ b/lib/fauxhai/platforms/ubuntu/13.10.json
@@ -483,12 +483,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ubuntu/14.04.json
+++ b/lib/fauxhai/platforms/ubuntu/14.04.json
@@ -525,7 +525,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/ubuntu/14.04.json
+++ b/lib/fauxhai/platforms/ubuntu/14.04.json
@@ -541,12 +541,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ubuntu/14.10.json
+++ b/lib/fauxhai/platforms/ubuntu/14.10.json
@@ -562,7 +562,6 @@
     "default_gateway": "10.0.0.1",
     "default_interface": "eth0",
     "settings": {
-
     },
     "interfaces": {
       "eth0": {
@@ -587,12 +586,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ubuntu/14.10.json
+++ b/lib/fauxhai/platforms/ubuntu/14.10.json
@@ -571,7 +571,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/ubuntu/15.04.json
+++ b/lib/fauxhai/platforms/ubuntu/15.04.json
@@ -605,7 +605,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/ubuntu/15.04.json
+++ b/lib/fauxhai/platforms/ubuntu/15.04.json
@@ -621,12 +621,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ubuntu/15.10.json
+++ b/lib/fauxhai/platforms/ubuntu/15.10.json
@@ -613,7 +613,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/ubuntu/15.10.json
+++ b/lib/fauxhai/platforms/ubuntu/15.10.json
@@ -629,12 +629,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ubuntu/16.04.json
+++ b/lib/fauxhai/platforms/ubuntu/16.04.json
@@ -842,12 +842,15 @@
         ],
         "mtu": "1500",
         "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
             "scope": "link",
+            "proto": "kernel",
             "src": "10.0.0.2"
           }
-        },
+        ],
         "state": "up",
         "type": "eth"
       }

--- a/lib/fauxhai/platforms/ubuntu/16.04.json
+++ b/lib/fauxhai/platforms/ubuntu/16.04.json
@@ -826,7 +826,7 @@
             "broadcast": "10.0.0.255",
             "family": "inet",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
+            "prefixlen": "24",
             "scope": "Global"
           }
         },

--- a/lib/fauxhai/platforms/windows/10.json
+++ b/lib/fauxhai/platforms/windows/10.json
@@ -3495,43 +3495,108 @@
   },
   "macaddress": "11:11:11:11:11:11",
   "network": {
-    "default_gateway": "10.0.0.1",
-    "default_interface": "eth0",
-    "settings": {
-    },
     "interfaces": {
-      "eth0": {
+      "0xe": {
+        "configuration": {
+          "caption": "[00000012] Ethernet Adapter",
+          "database_path": "%SystemRoot%\\System32\\drivers\\etc",
+          "default_ip_gateway": [
+            "default_gateway"
+          ],
+          "description": "Ethernet Adapter",
+          "dhcp_enabled": false,
+          "dns_domain_suffix_search_order": [
+
+          ],
+          "dns_enabled_for_wins_resolution": false,
+          "dns_host_name": "Fauxhai",
+          "domain_dns_registration_enabled": false,
+          "full_dns_registration_enabled": true,
+          "gateway_cost_metric": [
+            0
+          ],
+          "index": 12,
+          "interface_index": 14,
+          "ip_address": [
+            "10.0.0.2"
+          ],
+          "ip_connection_metric": 5,
+          "ip_enabled": true,
+          "ip_filter_security_enabled": false,
+          "ip_sec_permit_ip_protocols": [
+
+          ],
+          "ip_sec_permit_tcp_ports": [
+
+          ],
+          "ip_sec_permit_udp_ports": [
+
+          ],
+          "ip_subnet": [
+            "255.255.255.0",
+            "64"
+          ],
+          "mac_address": "11:11:11:11:11:11",
+          "service_name": "netkvm",
+          "setting_id": "{00000000-0000-0000-0000-000000000000}",
+          "tcpip_netbios_options": 0,
+          "tcp_window_size": 64240,
+          "wins_enable_lm_hosts_lookup": true,
+          "wins_scope_id": ""
+        },
+        "instance": {
+          "adapter_type": "Ethernet 802.3",
+          "adapter_type_id": 0,
+          "availability": 3,
+          "caption": "[00000012] Ethernet Adapter",
+          "config_manager_error_code": 0,
+          "config_manager_user_config": false,
+          "creation_class_name": "Win32_NetworkAdapter",
+          "description": "Ethernet Adapter",
+          "device_id": "12",
+          "guid": "{00000000-0000-0000-0000-000000000000}",
+          "index": 12,
+          "installed": true,
+          "interface_index": 14,
+          "mac_address": "11:11:11:11:11:11",
+          "manufacturer": "",
+          "max_number_controlled": 0,
+          "name": "Ethernet Adapter",
+          "net_connection_id": "Ethernet",
+          "net_connection_status": 2,
+          "net_enabled": true,
+          "physical_adapter": true,
+          "pnp_device_id": "PCI\\VEN_0000&DEV_0000&SUBSYS_000000000&REV_00\\0&0000000000&00",
+          "power_management_supported": false,
+          "product_name": "Ethernet Adapter",
+          "service_name": "netkvm",
+          "speed": "10000000000",
+          "system_creation_class_name": "Win32_ComputerSystem",
+          "system_name": "Fauxhai",
+          "time_of_last_reset": "20000101000001.000000+000"
+        },
+        "counters": {
+        },
         "addresses": {
           "10.0.0.2": {
-            "broadcast": "10.0.0.255",
-            "family": "inet",
+            "prefixlen": "24",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
-            "scope": "Global"
+            "broadcast": "10.0.0.255",
+            "family": "inet"
+          },
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
           }
         },
+        "type": "Ethernet 802.3",
         "arp": {
           "10.0.0.1": "fe:ff:ff:ff:ff:ff"
         },
-        "encapsulation": "Ethernet",
-        "flags": [
-          "BROADCAST",
-          "MULTICAST",
-          "UP",
-          "LOWER_UP"
-        ],
-        "mtu": "1500",
-        "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
-            "scope": "link",
-            "src": "10.0.0.2"
-          }
-        },
-        "state": "up",
-        "type": "eth"
+        "encapsulation": "Ethernet"
       }
-    }
+    },
+    "default_gateway": "10.0.0.1",
+    "default_interface": "0xe"
   },
   "uptime": "30 days 15 hours 07 minutes 30 seconds",
   "uptime_seconds": 2646450,

--- a/lib/fauxhai/platforms/windows/2003R2.json
+++ b/lib/fauxhai/platforms/windows/2003R2.json
@@ -7836,44 +7836,108 @@
   },
   "macaddress": "11:11:11:11:11:11",
   "network": {
-    "default_gateway": "10.0.0.1",
-    "default_interface": "eth0",
-    "settings": {
-
-    },
     "interfaces": {
-      "eth0": {
+      "0xe": {
+        "configuration": {
+          "caption": "[00000012] Ethernet Adapter",
+          "database_path": "%SystemRoot%\\System32\\drivers\\etc",
+          "default_ip_gateway": [
+            "default_gateway"
+          ],
+          "description": "Ethernet Adapter",
+          "dhcp_enabled": false,
+          "dns_domain_suffix_search_order": [
+
+          ],
+          "dns_enabled_for_wins_resolution": false,
+          "dns_host_name": "Fauxhai",
+          "domain_dns_registration_enabled": false,
+          "full_dns_registration_enabled": true,
+          "gateway_cost_metric": [
+            0
+          ],
+          "index": 12,
+          "interface_index": 14,
+          "ip_address": [
+            "10.0.0.2"
+          ],
+          "ip_connection_metric": 5,
+          "ip_enabled": true,
+          "ip_filter_security_enabled": false,
+          "ip_sec_permit_ip_protocols": [
+
+          ],
+          "ip_sec_permit_tcp_ports": [
+
+          ],
+          "ip_sec_permit_udp_ports": [
+
+          ],
+          "ip_subnet": [
+            "255.255.255.0",
+            "64"
+          ],
+          "mac_address": "11:11:11:11:11:11",
+          "service_name": "netkvm",
+          "setting_id": "{00000000-0000-0000-0000-000000000000}",
+          "tcpip_netbios_options": 0,
+          "tcp_window_size": 64240,
+          "wins_enable_lm_hosts_lookup": true,
+          "wins_scope_id": ""
+        },
+        "instance": {
+          "adapter_type": "Ethernet 802.3",
+          "adapter_type_id": 0,
+          "availability": 3,
+          "caption": "[00000012] Ethernet Adapter",
+          "config_manager_error_code": 0,
+          "config_manager_user_config": false,
+          "creation_class_name": "Win32_NetworkAdapter",
+          "description": "Ethernet Adapter",
+          "device_id": "12",
+          "guid": "{00000000-0000-0000-0000-000000000000}",
+          "index": 12,
+          "installed": true,
+          "interface_index": 14,
+          "mac_address": "11:11:11:11:11:11",
+          "manufacturer": "",
+          "max_number_controlled": 0,
+          "name": "Ethernet Adapter",
+          "net_connection_id": "Ethernet",
+          "net_connection_status": 2,
+          "net_enabled": true,
+          "physical_adapter": true,
+          "pnp_device_id": "PCI\\VEN_0000&DEV_0000&SUBSYS_000000000&REV_00\\0&0000000000&00",
+          "power_management_supported": false,
+          "product_name": "Ethernet Adapter",
+          "service_name": "netkvm",
+          "speed": "10000000000",
+          "system_creation_class_name": "Win32_ComputerSystem",
+          "system_name": "Fauxhai",
+          "time_of_last_reset": "20000101000001.000000+000"
+        },
+        "counters": {
+        },
         "addresses": {
           "10.0.0.2": {
-            "broadcast": "10.0.0.255",
-            "family": "inet",
+            "prefixlen": "24",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
-            "scope": "Global"
+            "broadcast": "10.0.0.255",
+            "family": "inet"
+          },
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
           }
         },
+        "type": "Ethernet 802.3",
         "arp": {
           "10.0.0.1": "fe:ff:ff:ff:ff:ff"
         },
-        "encapsulation": "Ethernet",
-        "flags": [
-          "BROADCAST",
-          "MULTICAST",
-          "UP",
-          "LOWER_UP"
-        ],
-        "mtu": "1500",
-        "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
-            "scope": "link",
-            "src": "10.0.0.2"
-          }
-        },
-        "state": "up",
-        "type": "eth"
+        "encapsulation": "Ethernet"
       }
-    }
+    },
+    "default_gateway": "10.0.0.1",
+    "default_interface": "0xe"
   },
   "uptime": "30 days 15 hours 07 minutes 30 seconds",
   "uptime_seconds": 2646450,

--- a/lib/fauxhai/platforms/windows/2008R2.json
+++ b/lib/fauxhai/platforms/windows/2008R2.json
@@ -5870,43 +5870,108 @@
   },
   "macaddress": "11:11:11:11:11:11",
   "network": {
-    "default_gateway": "10.0.0.1",
-    "default_interface": "eth0",
-    "settings": {
-    },
     "interfaces": {
-      "eth0": {
+      "0xe": {
+        "configuration": {
+          "caption": "[00000012] Ethernet Adapter",
+          "database_path": "%SystemRoot%\\System32\\drivers\\etc",
+          "default_ip_gateway": [
+            "default_gateway"
+          ],
+          "description": "Ethernet Adapter",
+          "dhcp_enabled": false,
+          "dns_domain_suffix_search_order": [
+
+          ],
+          "dns_enabled_for_wins_resolution": false,
+          "dns_host_name": "Fauxhai",
+          "domain_dns_registration_enabled": false,
+          "full_dns_registration_enabled": true,
+          "gateway_cost_metric": [
+            0
+          ],
+          "index": 12,
+          "interface_index": 14,
+          "ip_address": [
+            "10.0.0.2"
+          ],
+          "ip_connection_metric": 5,
+          "ip_enabled": true,
+          "ip_filter_security_enabled": false,
+          "ip_sec_permit_ip_protocols": [
+
+          ],
+          "ip_sec_permit_tcp_ports": [
+
+          ],
+          "ip_sec_permit_udp_ports": [
+
+          ],
+          "ip_subnet": [
+            "255.255.255.0",
+            "64"
+          ],
+          "mac_address": "11:11:11:11:11:11",
+          "service_name": "netkvm",
+          "setting_id": "{00000000-0000-0000-0000-000000000000}",
+          "tcpip_netbios_options": 0,
+          "tcp_window_size": 64240,
+          "wins_enable_lm_hosts_lookup": true,
+          "wins_scope_id": ""
+        },
+        "instance": {
+          "adapter_type": "Ethernet 802.3",
+          "adapter_type_id": 0,
+          "availability": 3,
+          "caption": "[00000012] Ethernet Adapter",
+          "config_manager_error_code": 0,
+          "config_manager_user_config": false,
+          "creation_class_name": "Win32_NetworkAdapter",
+          "description": "Ethernet Adapter",
+          "device_id": "12",
+          "guid": "{00000000-0000-0000-0000-000000000000}",
+          "index": 12,
+          "installed": true,
+          "interface_index": 14,
+          "mac_address": "11:11:11:11:11:11",
+          "manufacturer": "",
+          "max_number_controlled": 0,
+          "name": "Ethernet Adapter",
+          "net_connection_id": "Ethernet",
+          "net_connection_status": 2,
+          "net_enabled": true,
+          "physical_adapter": true,
+          "pnp_device_id": "PCI\\VEN_0000&DEV_0000&SUBSYS_000000000&REV_00\\0&0000000000&00",
+          "power_management_supported": false,
+          "product_name": "Ethernet Adapter",
+          "service_name": "netkvm",
+          "speed": "10000000000",
+          "system_creation_class_name": "Win32_ComputerSystem",
+          "system_name": "Fauxhai",
+          "time_of_last_reset": "20000101000001.000000+000"
+        },
+        "counters": {
+        },
         "addresses": {
           "10.0.0.2": {
-            "broadcast": "10.0.0.255",
-            "family": "inet",
+            "prefixlen": "24",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
-            "scope": "Global"
+            "broadcast": "10.0.0.255",
+            "family": "inet"
+          },
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
           }
         },
+        "type": "Ethernet 802.3",
         "arp": {
           "10.0.0.1": "fe:ff:ff:ff:ff:ff"
         },
-        "encapsulation": "Ethernet",
-        "flags": [
-          "BROADCAST",
-          "MULTICAST",
-          "UP",
-          "LOWER_UP"
-        ],
-        "mtu": "1500",
-        "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
-            "scope": "link",
-            "src": "10.0.0.2"
-          }
-        },
-        "state": "up",
-        "type": "eth"
+        "encapsulation": "Ethernet"
       }
-    }
+    },
+    "default_gateway": "10.0.0.1",
+    "default_interface": "0xe"
   },
   "uptime": "30 days 15 hours 07 minutes 30 seconds",
   "uptime_seconds": 2646450,

--- a/lib/fauxhai/platforms/windows/2012.json
+++ b/lib/fauxhai/platforms/windows/2012.json
@@ -3526,43 +3526,108 @@
   },
   "macaddress": "11:11:11:11:11:11",
   "network": {
-    "default_gateway": "10.0.0.1",
-    "default_interface": "eth0",
-    "settings": {
-    },
     "interfaces": {
-      "eth0": {
+      "0xe": {
+        "configuration": {
+          "caption": "[00000012] Ethernet Adapter",
+          "database_path": "%SystemRoot%\\System32\\drivers\\etc",
+          "default_ip_gateway": [
+            "default_gateway"
+          ],
+          "description": "Ethernet Adapter",
+          "dhcp_enabled": false,
+          "dns_domain_suffix_search_order": [
+
+          ],
+          "dns_enabled_for_wins_resolution": false,
+          "dns_host_name": "Fauxhai",
+          "domain_dns_registration_enabled": false,
+          "full_dns_registration_enabled": true,
+          "gateway_cost_metric": [
+            0
+          ],
+          "index": 12,
+          "interface_index": 14,
+          "ip_address": [
+            "10.0.0.2"
+          ],
+          "ip_connection_metric": 5,
+          "ip_enabled": true,
+          "ip_filter_security_enabled": false,
+          "ip_sec_permit_ip_protocols": [
+
+          ],
+          "ip_sec_permit_tcp_ports": [
+
+          ],
+          "ip_sec_permit_udp_ports": [
+
+          ],
+          "ip_subnet": [
+            "255.255.255.0",
+            "64"
+          ],
+          "mac_address": "11:11:11:11:11:11",
+          "service_name": "netkvm",
+          "setting_id": "{00000000-0000-0000-0000-000000000000}",
+          "tcpip_netbios_options": 0,
+          "tcp_window_size": 64240,
+          "wins_enable_lm_hosts_lookup": true,
+          "wins_scope_id": ""
+        },
+        "instance": {
+          "adapter_type": "Ethernet 802.3",
+          "adapter_type_id": 0,
+          "availability": 3,
+          "caption": "[00000012] Ethernet Adapter",
+          "config_manager_error_code": 0,
+          "config_manager_user_config": false,
+          "creation_class_name": "Win32_NetworkAdapter",
+          "description": "Ethernet Adapter",
+          "device_id": "12",
+          "guid": "{00000000-0000-0000-0000-000000000000}",
+          "index": 12,
+          "installed": true,
+          "interface_index": 14,
+          "mac_address": "11:11:11:11:11:11",
+          "manufacturer": "",
+          "max_number_controlled": 0,
+          "name": "Ethernet Adapter",
+          "net_connection_id": "Ethernet",
+          "net_connection_status": 2,
+          "net_enabled": true,
+          "physical_adapter": true,
+          "pnp_device_id": "PCI\\VEN_0000&DEV_0000&SUBSYS_000000000&REV_00\\0&0000000000&00",
+          "power_management_supported": false,
+          "product_name": "Ethernet Adapter",
+          "service_name": "netkvm",
+          "speed": "10000000000",
+          "system_creation_class_name": "Win32_ComputerSystem",
+          "system_name": "Fauxhai",
+          "time_of_last_reset": "20000101000001.000000+000"
+        },
+        "counters": {
+        },
         "addresses": {
           "10.0.0.2": {
-            "broadcast": "10.0.0.255",
-            "family": "inet",
+            "prefixlen": "24",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
-            "scope": "Global"
+            "broadcast": "10.0.0.255",
+            "family": "inet"
+          },
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
           }
         },
+        "type": "Ethernet 802.3",
         "arp": {
           "10.0.0.1": "fe:ff:ff:ff:ff:ff"
         },
-        "encapsulation": "Ethernet",
-        "flags": [
-          "BROADCAST",
-          "MULTICAST",
-          "UP",
-          "LOWER_UP"
-        ],
-        "mtu": "1500",
-        "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
-            "scope": "link",
-            "src": "10.0.0.2"
-          }
-        },
-        "state": "up",
-        "type": "eth"
+        "encapsulation": "Ethernet"
       }
-    }
+    },
+    "default_gateway": "10.0.0.1",
+    "default_interface": "0xe"
   },
   "uptime": "30 days 15 hours 07 minutes 30 seconds",
   "uptime_seconds": 2646450,

--- a/lib/fauxhai/platforms/windows/2012R2.json
+++ b/lib/fauxhai/platforms/windows/2012R2.json
@@ -3720,43 +3720,108 @@
   },
   "macaddress": "11:11:11:11:11:11",
   "network": {
-    "default_gateway": "10.0.0.1",
-    "default_interface": "eth0",
-    "settings": {
-    },
     "interfaces": {
-      "eth0": {
+      "0xe": {
+        "configuration": {
+          "caption": "[00000012] Ethernet Adapter",
+          "database_path": "%SystemRoot%\\System32\\drivers\\etc",
+          "default_ip_gateway": [
+            "default_gateway"
+          ],
+          "description": "Ethernet Adapter",
+          "dhcp_enabled": false,
+          "dns_domain_suffix_search_order": [
+
+          ],
+          "dns_enabled_for_wins_resolution": false,
+          "dns_host_name": "Fauxhai",
+          "domain_dns_registration_enabled": false,
+          "full_dns_registration_enabled": true,
+          "gateway_cost_metric": [
+            0
+          ],
+          "index": 12,
+          "interface_index": 14,
+          "ip_address": [
+            "10.0.0.2"
+          ],
+          "ip_connection_metric": 5,
+          "ip_enabled": true,
+          "ip_filter_security_enabled": false,
+          "ip_sec_permit_ip_protocols": [
+
+          ],
+          "ip_sec_permit_tcp_ports": [
+
+          ],
+          "ip_sec_permit_udp_ports": [
+
+          ],
+          "ip_subnet": [
+            "255.255.255.0",
+            "64"
+          ],
+          "mac_address": "11:11:11:11:11:11",
+          "service_name": "netkvm",
+          "setting_id": "{00000000-0000-0000-0000-000000000000}",
+          "tcpip_netbios_options": 0,
+          "tcp_window_size": 64240,
+          "wins_enable_lm_hosts_lookup": true,
+          "wins_scope_id": ""
+        },
+        "instance": {
+          "adapter_type": "Ethernet 802.3",
+          "adapter_type_id": 0,
+          "availability": 3,
+          "caption": "[00000012] Ethernet Adapter",
+          "config_manager_error_code": 0,
+          "config_manager_user_config": false,
+          "creation_class_name": "Win32_NetworkAdapter",
+          "description": "Ethernet Adapter",
+          "device_id": "12",
+          "guid": "{00000000-0000-0000-0000-000000000000}",
+          "index": 12,
+          "installed": true,
+          "interface_index": 14,
+          "mac_address": "11:11:11:11:11:11",
+          "manufacturer": "",
+          "max_number_controlled": 0,
+          "name": "Ethernet Adapter",
+          "net_connection_id": "Ethernet",
+          "net_connection_status": 2,
+          "net_enabled": true,
+          "physical_adapter": true,
+          "pnp_device_id": "PCI\\VEN_0000&DEV_0000&SUBSYS_000000000&REV_00\\0&0000000000&00",
+          "power_management_supported": false,
+          "product_name": "Ethernet Adapter",
+          "service_name": "netkvm",
+          "speed": "10000000000",
+          "system_creation_class_name": "Win32_ComputerSystem",
+          "system_name": "Fauxhai",
+          "time_of_last_reset": "20000101000001.000000+000"
+        },
+        "counters": {
+        },
         "addresses": {
           "10.0.0.2": {
-            "broadcast": "10.0.0.255",
-            "family": "inet",
+            "prefixlen": "24",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
-            "scope": "Global"
+            "broadcast": "10.0.0.255",
+            "family": "inet"
+          },
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
           }
         },
+        "type": "Ethernet 802.3",
         "arp": {
           "10.0.0.1": "fe:ff:ff:ff:ff:ff"
         },
-        "encapsulation": "Ethernet",
-        "flags": [
-          "BROADCAST",
-          "MULTICAST",
-          "UP",
-          "LOWER_UP"
-        ],
-        "mtu": "1500",
-        "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
-            "scope": "link",
-            "src": "10.0.0.2"
-          }
-        },
-        "state": "up",
-        "type": "eth"
+        "encapsulation": "Ethernet"
       }
-    }
+    },
+    "default_gateway": "10.0.0.1",
+    "default_interface": "0xe"
   },
   "uptime": "30 days 15 hours 07 minutes 30 seconds",
   "uptime_seconds": 2646450,

--- a/lib/fauxhai/platforms/windows/8.1.json
+++ b/lib/fauxhai/platforms/windows/8.1.json
@@ -3462,43 +3462,108 @@
   },
   "macaddress": "11:11:11:11:11:11",
   "network": {
-    "default_gateway": "10.0.0.1",
-    "default_interface": "eth0",
-    "settings": {
-    },
     "interfaces": {
-      "eth0": {
+      "0xe": {
+        "configuration": {
+          "caption": "[00000012] Ethernet Adapter",
+          "database_path": "%SystemRoot%\\System32\\drivers\\etc",
+          "default_ip_gateway": [
+            "default_gateway"
+          ],
+          "description": "Ethernet Adapter",
+          "dhcp_enabled": false,
+          "dns_domain_suffix_search_order": [
+
+          ],
+          "dns_enabled_for_wins_resolution": false,
+          "dns_host_name": "Fauxhai",
+          "domain_dns_registration_enabled": false,
+          "full_dns_registration_enabled": true,
+          "gateway_cost_metric": [
+            0
+          ],
+          "index": 12,
+          "interface_index": 14,
+          "ip_address": [
+            "10.0.0.2"
+          ],
+          "ip_connection_metric": 5,
+          "ip_enabled": true,
+          "ip_filter_security_enabled": false,
+          "ip_sec_permit_ip_protocols": [
+
+          ],
+          "ip_sec_permit_tcp_ports": [
+
+          ],
+          "ip_sec_permit_udp_ports": [
+
+          ],
+          "ip_subnet": [
+            "255.255.255.0",
+            "64"
+          ],
+          "mac_address": "11:11:11:11:11:11",
+          "service_name": "netkvm",
+          "setting_id": "{00000000-0000-0000-0000-000000000000}",
+          "tcpip_netbios_options": 0,
+          "tcp_window_size": 64240,
+          "wins_enable_lm_hosts_lookup": true,
+          "wins_scope_id": ""
+        },
+        "instance": {
+          "adapter_type": "Ethernet 802.3",
+          "adapter_type_id": 0,
+          "availability": 3,
+          "caption": "[00000012] Ethernet Adapter",
+          "config_manager_error_code": 0,
+          "config_manager_user_config": false,
+          "creation_class_name": "Win32_NetworkAdapter",
+          "description": "Ethernet Adapter",
+          "device_id": "12",
+          "guid": "{00000000-0000-0000-0000-000000000000}",
+          "index": 12,
+          "installed": true,
+          "interface_index": 14,
+          "mac_address": "11:11:11:11:11:11",
+          "manufacturer": "",
+          "max_number_controlled": 0,
+          "name": "Ethernet Adapter",
+          "net_connection_id": "Ethernet",
+          "net_connection_status": 2,
+          "net_enabled": true,
+          "physical_adapter": true,
+          "pnp_device_id": "PCI\\VEN_0000&DEV_0000&SUBSYS_000000000&REV_00\\0&0000000000&00",
+          "power_management_supported": false,
+          "product_name": "Ethernet Adapter",
+          "service_name": "netkvm",
+          "speed": "10000000000",
+          "system_creation_class_name": "Win32_ComputerSystem",
+          "system_name": "Fauxhai",
+          "time_of_last_reset": "20000101000001.000000+000"
+        },
+        "counters": {
+        },
         "addresses": {
           "10.0.0.2": {
-            "broadcast": "10.0.0.255",
-            "family": "inet",
+            "prefixlen": "24",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
-            "scope": "Global"
+            "broadcast": "10.0.0.255",
+            "family": "inet"
+          },
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
           }
         },
+        "type": "Ethernet 802.3",
         "arp": {
           "10.0.0.1": "fe:ff:ff:ff:ff:ff"
         },
-        "encapsulation": "Ethernet",
-        "flags": [
-          "BROADCAST",
-          "MULTICAST",
-          "UP",
-          "LOWER_UP"
-        ],
-        "mtu": "1500",
-        "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
-            "scope": "link",
-            "src": "10.0.0.2"
-          }
-        },
-        "state": "up",
-        "type": "eth"
+        "encapsulation": "Ethernet"
       }
-    }
+    },
+    "default_gateway": "10.0.0.1",
+    "default_interface": "0xe"
   },
   "uptime": "30 days 15 hours 07 minutes 30 seconds",
   "uptime_seconds": 2646450,

--- a/lib/fauxhai/platforms/windows/8.json
+++ b/lib/fauxhai/platforms/windows/8.json
@@ -3876,43 +3876,108 @@
   },
   "macaddress": "11:11:11:11:11:11",
   "network": {
-    "default_gateway": "10.0.0.1",
-    "default_interface": "eth0",
-    "settings": {
-    },
     "interfaces": {
-      "eth0": {
+      "0xe": {
+        "configuration": {
+          "caption": "[00000012] Ethernet Adapter",
+          "database_path": "%SystemRoot%\\System32\\drivers\\etc",
+          "default_ip_gateway": [
+            "default_gateway"
+          ],
+          "description": "Ethernet Adapter",
+          "dhcp_enabled": false,
+          "dns_domain_suffix_search_order": [
+
+          ],
+          "dns_enabled_for_wins_resolution": false,
+          "dns_host_name": "Fauxhai",
+          "domain_dns_registration_enabled": false,
+          "full_dns_registration_enabled": true,
+          "gateway_cost_metric": [
+            0
+          ],
+          "index": 12,
+          "interface_index": 14,
+          "ip_address": [
+            "10.0.0.2"
+          ],
+          "ip_connection_metric": 5,
+          "ip_enabled": true,
+          "ip_filter_security_enabled": false,
+          "ip_sec_permit_ip_protocols": [
+
+          ],
+          "ip_sec_permit_tcp_ports": [
+
+          ],
+          "ip_sec_permit_udp_ports": [
+
+          ],
+          "ip_subnet": [
+            "255.255.255.0",
+            "64"
+          ],
+          "mac_address": "11:11:11:11:11:11",
+          "service_name": "netkvm",
+          "setting_id": "{00000000-0000-0000-0000-000000000000}",
+          "tcpip_netbios_options": 0,
+          "tcp_window_size": 64240,
+          "wins_enable_lm_hosts_lookup": true,
+          "wins_scope_id": ""
+        },
+        "instance": {
+          "adapter_type": "Ethernet 802.3",
+          "adapter_type_id": 0,
+          "availability": 3,
+          "caption": "[00000012] Ethernet Adapter",
+          "config_manager_error_code": 0,
+          "config_manager_user_config": false,
+          "creation_class_name": "Win32_NetworkAdapter",
+          "description": "Ethernet Adapter",
+          "device_id": "12",
+          "guid": "{00000000-0000-0000-0000-000000000000}",
+          "index": 12,
+          "installed": true,
+          "interface_index": 14,
+          "mac_address": "11:11:11:11:11:11",
+          "manufacturer": "",
+          "max_number_controlled": 0,
+          "name": "Ethernet Adapter",
+          "net_connection_id": "Ethernet",
+          "net_connection_status": 2,
+          "net_enabled": true,
+          "physical_adapter": true,
+          "pnp_device_id": "PCI\\VEN_0000&DEV_0000&SUBSYS_000000000&REV_00\\0&0000000000&00",
+          "power_management_supported": false,
+          "product_name": "Ethernet Adapter",
+          "service_name": "netkvm",
+          "speed": "10000000000",
+          "system_creation_class_name": "Win32_ComputerSystem",
+          "system_name": "Fauxhai",
+          "time_of_last_reset": "20000101000001.000000+000"
+        },
+        "counters": {
+        },
         "addresses": {
           "10.0.0.2": {
-            "broadcast": "10.0.0.255",
-            "family": "inet",
+            "prefixlen": "24",
             "netmask": "255.255.255.0",
-            "prefixlen": "23",
-            "scope": "Global"
+            "broadcast": "10.0.0.255",
+            "family": "inet"
+          },
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
           }
         },
+        "type": "Ethernet 802.3",
         "arp": {
           "10.0.0.1": "fe:ff:ff:ff:ff:ff"
         },
-        "encapsulation": "Ethernet",
-        "flags": [
-          "BROADCAST",
-          "MULTICAST",
-          "UP",
-          "LOWER_UP"
-        ],
-        "mtu": "1500",
-        "number": "0",
-        "routes": {
-          "10.0.0.0/255": {
-            "scope": "link",
-            "src": "10.0.0.2"
-          }
-        },
-        "state": "up",
-        "type": "eth"
+        "encapsulation": "Ethernet"
       }
-    }
+    },
+    "default_gateway": "10.0.0.1",
+    "default_interface": "0xe"
   },
   "uptime": "30 days 15 hours 07 minutes 30 seconds",
   "uptime_seconds": 2646450,


### PR DESCRIPTION
Some network ohai values were incorrect:

1. prefixlen is 23 instead of 24
2. routes is a hash instead of an array of hash (see #216)
3. windows ohai is completly wrong

#235 fix the runner implementation of the 2 last points, and this PR tries to fix all json files.

*Cc:* @aboten