### PR TITLE
Adding fauxhai dump for Raspbian 8.0

### DIFF
--- a/lib/fauxhai/platforms/8.0.json
+++ b/lib/fauxhai/platforms/8.0.json
@@ -1,0 +1,468 @@
+{
+  "command": {
+    "ps": "ps -ef"
+  },
+  "kernel": {
+    "name": "Linux",
+    "release": "4.4.9-v7+",
+    "version": "#884 SMP Fri May 6 17:28:59 BST 2016",
+    "machine": "armv7l",
+    "processor": "unknown",
+    "os": "GNU/Linux",
+    "modules": {
+      "bnep": {
+        "size": "10340",
+        "refcount": "2",
+        "version": "1.3"
+      },
+      "hci_uart": {
+        "size": "17943",
+        "refcount": "1",
+        "version": "2.3"
+      },
+      "btbcm": {
+        "size": "5929",
+        "refcount": "1",
+        "version": "0.1"
+      },
+      "bluetooth": {
+        "size": "326105",
+        "refcount": "22",
+        "version": "2.21"
+      },
+      "brcmfmac": {
+        "size": "186599",
+        "refcount": "0"
+      },
+      "evdev": {
+        "size": "11396",
+        "refcount": "4"
+      },
+      "joydev": {
+        "size": "9024",
+        "refcount": "0"
+      },
+      "brcmutil": {
+        "size": "5661",
+        "refcount": "1"
+      },
+      "cfg80211": {
+        "size": "427855",
+        "refcount": "1"
+      },
+      "rfkill": {
+        "size": "16037",
+        "refcount": "4"
+      },
+      "snd_bcm2835": {
+        "size": "20511",
+        "refcount": "1"
+      },
+      "snd_pcm": {
+        "size": "75698",
+        "refcount": "1"
+      },
+      "snd_timer": {
+        "size": "19160",
+        "refcount": "1"
+      },
+      "snd": {
+        "size": "51844",
+        "refcount": "5"
+      },
+      "bcm2835_wdt": {
+        "size": "3225",
+        "refcount": "0"
+      },
+      "bcm2835_gpiomem": {
+        "size": "3040",
+        "refcount": "0"
+      },
+      "uio_pdrv_genirq": {
+        "size": "3164",
+        "refcount": "0"
+      },
+      "uio": {
+        "size": "8000",
+        "refcount": "1"
+      },
+      "i2c_dev": {
+        "size": "5859",
+        "refcount": "0"
+      },
+      "fuse": {
+        "size": "83461",
+        "refcount": "3"
+      },
+      "ipv6": {
+        "size": "347530",
+        "refcount": "60"
+      }
+    }
+  },
+  "os": "linux",
+  "os_version": "4.4.9-v7+",
+  "lsb": {
+    "id": "Raspbian",
+    "description": "Raspbian GNU/Linux 8.0 (jessie)",
+    "release": "8.0",
+    "codename": "jessie"
+  },
+  "platform": "raspbian",
+  "platform_version": "8.0",
+  "platform_family": "debian",
+  "filesystem": {
+    "/dev/root": {
+      "kb_size": "60162140",
+      "kb_used": "4545664",
+      "kb_available": "52537308",
+      "percent_used": "8%",
+      "mount": "/",
+      "total_inodes": "3833856",
+      "inodes_used": "172418",
+      "inodes_available": "3661438",
+      "inodes_percent_used": "5%"
+    },
+    "devtmpfs": {
+      "kb_size": "469544",
+      "kb_used": "0",
+      "kb_available": "469544",
+      "percent_used": "0%",
+      "mount": "/dev",
+      "total_inodes": "117386",
+      "inodes_used": "379",
+      "inodes_available": "117007",
+      "inodes_percent_used": "1%",
+      "fs_type": "devtmpfs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "size=469544k",
+        "nr_inodes=117386",
+        "mode=755"
+      ]
+    },
+    "tmpfs": {
+      "kb_size": "94776",
+      "kb_used": "0",
+      "kb_available": "94776",
+      "percent_used": "0%",
+      "mount": "/run/user/1000",
+      "total_inodes": "118470",
+      "inodes_used": "6",
+      "inodes_available": "118464",
+      "inodes_percent_used": "1%",
+      "fs_type": "tmpfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=94776k",
+        "mode=700",
+        "uid=1000",
+        "gid=1000"
+      ]
+    },
+    "/dev/mmcblk0p6": {
+      "kb_size": "64366",
+      "kb_used": "20450",
+      "kb_available": "43916",
+      "percent_used": "32%",
+      "mount": "/boot",
+      "fs_type": "vfat",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "fmask=0022",
+        "dmask=0022",
+        "codepage=437",
+        "iocharset=ascii",
+        "shortname=mixed",
+        "errors=remount-ro"
+      ]
+    },
+    "/dev/mmcblk0p5": {
+      "kb_size": "30701",
+      "kb_used": "398",
+      "kb_available": "28010",
+      "percent_used": "2%",
+      "mount": "/media/pi/SETTINGS",
+      "total_inodes": "8192",
+      "inodes_used": "14",
+      "inodes_available": "8178",
+      "inodes_percent_used": "1%",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "data=ordered",
+        "uhelper=udisks2"
+      ]
+    },
+    "/dev/mmcblk0p7": {
+      "mount": "/",
+      "fs_type": "ext4",
+      "mount_options": [
+        "rw",
+        "noatime",
+        "data=ordered"
+      ]
+    },
+    "sysfs": {
+      "mount": "/sys",
+      "fs_type": "sysfs",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ]
+    },
+    "proc": {
+      "mount": "/proc",
+      "fs_type": "proc",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "devpts": {
+      "mount": "/dev/pts",
+      "fs_type": "devpts",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ]
+    },
+    "cgroup": {
+      "mount": "/sys/fs/cgroup/net_cls",
+      "fs_type": "cgroup",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime",
+        "net_cls"
+      ]
+    },
+    "systemd-1": {
+      "mount": "/proc/sys/fs/binfmt_misc",
+      "fs_type": "autofs",
+      "mount_options": [
+        "rw",
+        "relatime",
+        "fd=22",
+        "pgrp=1",
+        "timeout=300",
+        "minproto=5",
+        "maxproto=5",
+        "direct"
+      ]
+    },
+    "mqueue": {
+      "mount": "/dev/mqueue",
+      "fs_type": "mqueue",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "debugfs": {
+      "mount": "/sys/kernel/debug",
+      "fs_type": "debugfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "configfs": {
+      "mount": "/sys/kernel/config",
+      "fs_type": "configfs",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "fusectl": {
+      "mount": "/sys/fs/fuse/connections",
+      "fs_type": "fusectl",
+      "mount_options": [
+        "rw",
+        "relatime"
+      ]
+    },
+    "gvfsd-fuse": {
+      "mount": "/run/user/1000/gvfs",
+      "fs_type": "fuse.gvfsd-fuse",
+      "mount_options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "user_id=1000",
+        "group_id=1000"
+      ]
+    }
+  },
+  "dmi": {
+    "dmidecode_version": "2.12"
+  },
+  "ohai_time": 1467522696.1713433,
+  "root_group": "root",
+  "init_package": "systemd",
+  "languages": {
+    "ruby": {
+      "platform": "armv7l-linux-eabihf",
+      "version": "2.2.4",
+      "release_date": "2015-12-16",
+      "target": "armv7l-unknown-linux-gnueabihf",
+      "target_cpu": "armv7l",
+      "target_vendor": "unknown",
+      "target_os": "linux-eabihf",
+      "host": "armv7l-unknown-linux-gnueabihf",
+      "host_cpu": "armv7l",
+      "host_os": "linux-gnueabihf",
+      "host_vendor": "unknown",
+      "bin_dir": "/usr/local/bin",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "gems_dir": "/usr/local/gems",
+      "gem_bin": "/usr/local/bin/gem"
+    },
+    "powershell": null
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "12.11.18",
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.11.18/lib"
+    },
+    "ohai": {
+      "version": "8.17.1",
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.17.1/lib/ohai"
+    }
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": "0",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "frame": 0,
+            "compressed": 0,
+            "multicast": 0
+          },
+          "tx": {
+            "bytes": "342",
+            "packets": "0",
+            "errors": "0",
+            "drop": 0,
+            "overrun": 0,
+            "collisions": "0",
+            "carrier": 0,
+            "compressed": 0
+          }
+        }
+      }
+    }
+  },
+  "current_user": "fauxhai",
+  "domain": "local",
+  "etc": {
+    "passwd": {
+      "fauxhai": {
+        "dir": "/home/fauxhai",
+        "gid": 0,
+        "uid": 0,
+        "shell": "/bin/bash",
+        "gecos": "Fauxhai"
+      }
+    },
+    "group": {
+      "fauxhai": {
+        "gid": 0,
+        "members": [
+          "fauxhai"
+        ]
+      }
+    }
+  },
+  "hostname": "Fauxhai",
+  "fqdn": "fauxhai.local",
+  "ipaddress": "10.0.0.2",
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "settings": {
+    },
+    "interfaces": {
+      "eth0": {
+        "addresses": {
+          "10.0.0.2": {
+            "broadcast": "10.0.0.255",
+            "family": "inet",
+            "netmask": "255.255.255.0",
+            "prefixlen": "24",
+            "scope": "Global"
+          }
+        },
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "encapsulation": "Ethernet",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "1500",
+        "number": "0",
+        "routes": [
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
+            "scope": "link",
+            "proto": "kernel",
+            "src": "10.0.0.2"
+          }
+        ],
+        "state": "up",
+        "type": "eth"
+      }
+    }
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "cpu": {
+    "real": 1,
+    "total": 1,
+    "cores": 1
+  },
+  "memory": {
+    "total": "1048576kB"
+  },
+  "virtualization": {
+    "systems": {
+    }
+  }
+}


### PR DESCRIPTION
I've managed to extract fauxhai data from Raspberry Pi!

 - Installed Chef `12.11.18` with a `knife bootstrap` script from [dayne/raspbian_bootstrap][1].
 - Ran:
   - `export GEM_HOME=/opt/chef/lib/ruby/gems/2.2.0/; export GEM_PATH=/opt/chef/lib/ruby/gems/2.2.0/; export GEM_ROOT="/opt/chef/lib/ruby/gems/2.2.0/"`
   - `sudo -E gem install fauxhai`
   - `/opt/chef/bin/fauxhai > /tmp/raspbian-8.0.json`

[1]: https://github.com/dayne/raspbian_bootstrap/blob/master/raspbian-wheezy-gems.erb