### PR TITLE
set default platform to ubuntu 16.04

### DIFF
--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -79,7 +79,10 @@ module Fauxhai
     end
 
     def platform
-      @options[:platform] ||= 'chefspec'
+      @options[:platform] ||= begin
+                                @using_default_platform = true
+                                'ubuntu'
+                              end
     end
 
     def platform_path
@@ -87,11 +90,13 @@ module Fauxhai
     end
 
     def version
-      @options[:version] ||= chefspec_version || raise(Fauxhai::Exception::InvalidVersion.new('Platform version not specified'))
-    end
-
-    def chefspec_version
-      platform == 'chefspec' ? '0.6.1' : nil
+      @options[:version] ||= begin
+                               if @using_default_platform
+                                 '16.04'
+                               else
+                                 raise(Fauxhai::Exception::InvalidVersion.new('Platform version not specified'))
+                               end
+                             end
     end
   end
 end


### PR DESCRIPTION
the chefspec 0.6.1 platform is a meaningless state that chef can
never get into.   we have to either pick a sensible default for
chefspec, or else we have to raise and just piss the user off by
forcing them to set a valid platform every time.  i'm currently
feeling grouchy so the latter is what i'd really enjoy doing, but
that'll probably break too much code in the world.

so users will get ubuntu 16.04 by default now.  5 years from now this
will probably be looked upon as a horrible decision as we bump
the default version to 20.04 and have to break everyone again.

i tried to be reasonably careful here so that we didn't accidentally
wind up with '16.04' being a default for only the 'ubuntu' platform --
since i'm sure some lazy person would omit the platform version and see
that it works and think that was convenient, and then get broken
horribly when we bump the default to '20.04'
Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>