### PR TITLE
Require Ruby 2.2.2 due to Rack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 sudo: false
 
 rvm:
- - 2.1.9
  - 2.2.5
  - 2.3.1
 

--- a/fauxhai.gemspec
+++ b/fauxhai.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/customink/fauxhai'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.2.2'
 
   spec.files         = `git ls-files`.split($\)
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }


### PR DESCRIPTION
Rack now requires Ruby 2.2.2 and Chef no longer pins to old rack. This
means we need Ruby 2.2.2+ to get the development gems to install.

Signed-off-by: Tim Smith <tsmith@chef.io>