### PR TITLE
Add init_package attribute to OpenSuse 13.2

### DIFF
--- a/lib/fauxhai/platforms/opensuse/13.2.json
+++ b/lib/fauxhai/platforms/opensuse/13.2.json
@@ -507,6 +507,7 @@
   },
   "ohai_time": 1445978780.543846,
   "root_group": "root",
+  "init_package": "systemd",
   "languages": {
     "ruby": {
       "platform": "x86_64-linux-gnu",


### PR DESCRIPTION
The `init_package` attribute was missing from `opensuse/13.2.json`.

Discovered while debugging the following failed test:
https://travis-ci.org/chef-cookbooks/chef_nginx/jobs/171427007#L327
