### PR TITLE
Better mock / whitelist data for modern Ohai

### DIFF
--- a/lib/fauxhai/fetcher.rb
+++ b/lib/fauxhai/fetcher.rb
@@ -45,7 +45,7 @@ module Fauxhai
     end
 
     def cache_file
-      File.expand_path( File.join(Fauxhai.root, 'tmp', cache_key) )
+      File.expand_path(File.join(Fauxhai.root, 'tmp', cache_key))
     end
 
     def force_cache_miss?

--- a/lib/fauxhai/mocker.rb
+++ b/lib/fauxhai/mocker.rb
@@ -5,10 +5,10 @@ require 'open-uri'
 module Fauxhai
   class Mocker
     # The base URL for the GitHub project (raw)
-    RAW_BASE = 'https://raw.githubusercontent.com/customink/fauxhai/master'
+    RAW_BASE = 'https://raw.githubusercontent.com/customink/fauxhai/master'.freeze
 
     # A message about where to find a list of platforms
-    PLATFORM_LIST_MESSAGE = "A list of available platforms is available at https://github.com/customink/fauxhai/blob/master/PLATFORMS.md".freeze
+    PLATFORM_LIST_MESSAGE = 'A list of available platforms is available at https://github.com/customink/fauxhai/blob/master/PLATFORMS.md'.freeze
 
     # @return [Hash] The raw ohai data for the given Mock
     attr_reader :data
@@ -50,7 +50,7 @@ module Fauxhai
         end
 
         if File.exist?(filepath)
-          JSON.parse( File.read(filepath) )
+          JSON.parse(File.read(filepath))
         elsif @options[:github_fetching]
           # Try loading from github (in case someone submitted a PR with a new file, but we haven't
           # yet updated the gem version). Cache the response locally so it's faster next time.

--- a/lib/fauxhai/runner.rb
+++ b/lib/fauxhai/runner.rb
@@ -33,7 +33,8 @@ module Fauxhai
         'uptime_seconds' => uptime_seconds,
         'cpu' => cpu,
         'memory' => memory,
-        'virtualization' => virtualization
+        'virtualization' => virtualization,
+        'time' => time
       )
 
       puts JSON.pretty_generate(result)

--- a/lib/fauxhai/runner/default.rb
+++ b/lib/fauxhai/runner/default.rb
@@ -14,11 +14,11 @@ module Fauxhai
         {
           'chef' => {
             'version' => chef_version,
-            'chef_root' => ['/opt/chef/embedded/lib/ruby/gems/2.1.0/gems', "chef-#{chef_version}", 'lib'].join('/')
+            'chef_root' => ['/opt/chef/embedded/lib/ruby/gems/2.4.0/gems', "chef-#{chef_version}", 'lib'].join('/')
           },
           'ohai' => {
             'version' => ohai_version,
-            'ohai_root' => ['/opt/chef/embedded/lib/ruby/gems/2.1.0/gems', "ohai-#{ohai_version}", 'lib', 'ohai'].join('/')
+            'ohai_root' => ['/opt/chef/embedded/lib/ruby/gems/2.4.0/gems', "ohai-#{ohai_version}", 'lib', 'ohai'].join('/')
           }
         }
       end
@@ -214,6 +214,12 @@ module Fauxhai
         }
       end
 
+      def time
+        {
+          'timezone' => 'GMT'
+        }
+      end
+
       # Whitelist attributes are attributes that we *actually* want from the node. Other attributes are
       # either ignored or overridden, but we ensure these are returned with the command.
       #
@@ -233,7 +239,10 @@ module Fauxhai
           platform_build
           platform_family
           init_package
-          root_group)
+          root_group
+          shard_seed
+          shells
+        )
       end
     end
   end

--- a/lib/fauxhai/version.rb
+++ b/lib/fauxhai/version.rb
@@ -1,3 +1,3 @@
 module Fauxhai
-  VERSION = '4.1.0'
+  VERSION = '4.1.0'.freeze
 end


### PR DESCRIPTION
Mock out the timezone to always be GMT
Whitelist shard_seed and shells data
Mock the Ruby path to be Ruby 2.4.0 not 2.1.0

Signed-off-by: Tim Smith <tsmith@chef.io>